### PR TITLE
Add GitHub Pages redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 This project provides an interactive simulator with database-backed materials and robust material defense calculations.
 
+## Live demo
+
+Visit [https://shmerrick.github.io/webgame/](https://shmerrick.github.io/webgame/) to use the simulator on GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=public/index.html" />
+  </head>
+  <body>
+    <p>If you are not redirected automatically, follow this <a href="public/index.html">link to the simulator</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add root `index.html` that redirects visitors to the simulator in `public/index.html`
- Document the live demo URL in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac822a3184833094d4453dcafb5c80