### PR TITLE
Fix defense calculations and add crafting material categories

### DIFF
--- a/public/crafting.html
+++ b/public/crafting.html
@@ -93,12 +93,24 @@
                     <input type="text" id="armor-name" name="armor-name" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white" />
                   </div>
                   <div>
-                    <label for="outer-material" class="block text-sm font-medium text-slate-300">Outer Layer</label>
+                    <label for="outer-category" class="block text-sm font-medium text-slate-300">Outer Category</label>
+                    <select id="outer-category" name="outer-category" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
+                  </div>
+                  <div>
+                    <label for="outer-material" class="block text-sm font-medium text-slate-300">Outer Material</label>
                     <select id="outer-material" name="outer-material" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
+                  </div>
+                  <div>
+                    <label for="inner-category" class="block text-sm font-medium text-slate-300">Inner Category</label>
+                    <select id="inner-category" name="inner-category" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
                   </div>
                   <div>
                     <label for="inner-material" class="block text-sm font-medium text-slate-300">Inner Layer</label>
                     <select id="inner-material" name="inner-material" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
+                  </div>
+                  <div>
+                    <label for="binding-category" class="block text-sm font-medium text-slate-300">Binding Category</label>
+                    <select id="binding-category" name="binding-category" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
                   </div>
                   <div>
                     <label for="binding-material" class="block text-sm font-medium text-slate-300">Binding</label>


### PR DESCRIPTION
## Summary
- Apply material physical and defensive factors when computing armor resistances
- Allow choosing material categories on crafting calculator and derive magic resist from elemental factors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac8df7d85c8330aef5407937e39f11