### PR TITLE
Populate metal resources with derived combat factors

### DIFF
--- a/public/Master_Elemental_Metals.json
+++ b/public/Master_Elemental_Metals.json
@@ -76,6 +76,18 @@
           "value": 0.000178,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0.10909090909090909,
+        "pierce": 0,
+        "blunt": 0.013144963144963145,
+        "defense_slash": 0,
+        "defense_pierce": 0.10909090909090909,
+        "defense_blunt": 0.013144963144963145,
+        "fire": 0.12277401894451961,
+        "water": 0.9868550368550368,
+        "wind": 0.2677144922266068,
+        "earth": 0.013144963144963145
       }
     },
     {
@@ -154,6 +166,18 @@
           "value": -0.0001136,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 1,
+        "pierce": 0,
+        "blunt": 0.04540540540540541,
+        "defense_slash": 0,
+        "defense_pierce": 1,
+        "defense_blunt": 0.04540540540540541,
+        "fire": 0.42219215155615697,
+        "water": 0.9545945945945946,
+        "wind": -0.21549111772549123,
+        "earth": 0.04540540540540541
       }
     },
     {
@@ -232,6 +256,18 @@
           "value": 0.0002,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0.09090909090909091,
+        "pierce": 0,
+        "blunt": 0.02378378378378378,
+        "defense_slash": 0,
+        "defense_pierce": 0.09090909090909091,
+        "defense_blunt": 0.02378378378378378,
+        "fire": 0.10039079837618403,
+        "water": 0.9762162162162162,
+        "wind": 0.23734101918319886,
+        "earth": 0.02378378378378378
       }
     },
     {
@@ -310,6 +346,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.0427027027027027,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.0427027027027027,
+        "fire": 0.24979702300405954,
+        "water": 0.9572972972972973,
+        "wind": -0.17957593143790937,
+        "earth": 0.0427027027027027
       }
     },
     {
@@ -388,6 +436,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.06633906633906633,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.06633906633906633,
+        "fire": 0.25263058186738835,
+        "water": 0.9336609336609336,
+        "wind": 0.18748625121774928,
+        "earth": 0.06633906633906633
       }
     },
     {
@@ -466,6 +526,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.021179361179361176,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.021179361179361176,
+        "fire": 0.09112313937753722,
+        "water": 0.9788206388206389,
+        "wind": 0.21721055726900923,
+        "earth": 0.021179361179361176
       }
     },
     {
@@ -544,6 +616,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.03808353808353808,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.03808353808353808,
+        "fire": 0.3017591339648173,
+        "water": 0.961916461916462,
+        "wind": 0.01063987393769613,
+        "earth": 0.03808353808353808
       }
     },
     {
@@ -622,6 +706,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.07334152334152333,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.07334152334152333,
+        "fire": 0.4909336941813261,
+        "water": 0.9266584766584767,
+        "wind": 0.08080916914705921,
+        "earth": 0.07334152334152333
       }
     },
     {
@@ -700,6 +796,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1107125307125307,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1107125307125307,
+        "fire": 0.5253044654939107,
+        "water": 0.8892874692874693,
+        "wind": 0.032723224106273034,
+        "earth": 0.1107125307125307
       }
     },
     {
@@ -778,6 +886,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.14742014742014742,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.14742014742014742,
+        "fire": 0.5907983761840325,
+        "water": 0.8525798525798526,
+        "wind": 0.2285597561358851,
+        "earth": 0.14742014742014742
       }
     },
     {
@@ -856,6 +976,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.17665847665847664,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.17665847665847664,
+        "fire": 0.5899864682002707,
+        "water": 0.8233415233415233,
+        "wind": 0.2927536622266517,
+        "earth": 0.17665847665847664
       }
     },
     {
@@ -934,6 +1066,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.17714987714987715,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.17714987714987715,
+        "fire": 0.4110960757780785,
+        "water": 0.8228501228501228,
+        "wind": -0.22446991429738672,
+        "earth": 0.17714987714987715
       }
     },
     {
@@ -1012,6 +1156,18 @@
           "value": 0.001,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0.7272727272727273,
+        "pierce": 0.31759656652360513,
+        "blunt": 0.19346437346437345,
+        "defense_slash": 0.17435897435897435,
+        "defense_pierce": 0.7272727272727273,
+        "defense_blunt": 0.19346437346437345,
+        "fire": 0.4901217861975643,
+        "water": 0.8065356265356265,
+        "wind": 0.06637575365773725,
+        "earth": 0.19346437346437345
       }
     },
     {
@@ -1090,6 +1246,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.21867321867321868,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.21867321867321868,
+        "fire": 0.47848443843031124,
+        "water": 0.7813267813267813,
+        "wind": 0.2868635716754883,
+        "earth": 0.21867321867321868
       }
     },
     {
@@ -1168,6 +1336,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.21886977886977885,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.21886977886977885,
+        "fire": 0.46765899864682003,
+        "water": 0.7811302211302211,
+        "wind": 0.5012413186260646,
+        "earth": 0.21886977886977885
       }
     },
     {
@@ -1183,27 +1363,27 @@
       "electronegativity_pauling": 1.9,
       "mechanical_properties": {
         "ultimate_tensile_strength": {
-          "value": 210.0,
+          "value": 210,
           "units": "MPa"
         },
         "yield_strength": {
-          "value": 33.0,
+          "value": 33,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": 120.0,
+          "value": 120,
           "units": "GPa"
         },
         "mohs_hardness": {
-          "value": 3.0,
+          "value": 3,
           "units": null
         },
         "brinell_hardness": {
-          "value": 250.0,
+          "value": 250,
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": 350.0,
+          "value": 350,
           "units": "MPa"
         },
         "density": {
@@ -1215,11 +1395,11 @@
           "units": "°C"
         },
         "boiling_point": {
-          "value": 2562.0,
+          "value": 2562,
           "units": "°C"
         },
         "thermal_conductivity": {
-          "value": 401.0,
+          "value": 401,
           "units": "W/m·K"
         },
         "thermal_expansion_coefficient": {
@@ -1243,9 +1423,21 @@
           "units": "nΩ·m"
         },
         "magnetic_susceptibility": {
-          "value": -5.46e-06,
+          "value": -0.00000546,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0.5454545454545454,
+        "pierce": 0.18025751072961374,
+        "blunt": 0.21916461916461916,
+        "defense_slash": 0.033846153846153845,
+        "defense_pierce": 0.5454545454545454,
+        "defense_blunt": 0.21916461916461916,
+        "fire": 0.36746143437077133,
+        "water": 0.7808353808353808,
+        "wind": 0.5352934046249781,
+        "earth": 0.21916461916461916
       }
     },
     {
@@ -1324,6 +1516,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1754299754299754,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1754299754299754,
+        "fire": 0.18746414073071718,
+        "water": 0.8245700245700246,
+        "wind": -0.26038510058496855,
+        "earth": 0.1754299754299754
       }
     },
     {
@@ -1402,6 +1606,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1452088452088452,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1452088452088452,
+        "fire": 0.08197959404600812,
+        "water": 0.8547911547911549,
+        "wind": 0.1840653297238571,
+        "earth": 0.1452088452088452
       }
     },
     {
@@ -1480,6 +1696,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.037641277641277636,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.037641277641277636,
+        "fire": 0.08456021650879567,
+        "water": 0.9623587223587223,
+        "wind": 0.21048094923837357,
+        "earth": 0.037641277641277636
       }
     },
     {
@@ -1558,6 +1786,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.06486486486486487,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.06486486486486487,
+        "fire": 0.28416779431664413,
+        "water": 0.9351351351351351,
+        "wind": 0.022550247590315466,
+        "earth": 0.06486486486486487
       }
     },
     {
@@ -1636,6 +1876,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.10987714987714987,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.10987714987714987,
+        "fire": 0.4868741542625169,
+        "water": 0.8901228501228501,
+        "wind": 0.13288618926405293,
+        "earth": 0.10987714987714987
       }
     },
     {
@@ -1714,6 +1966,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.16019656019656017,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.16019656019656017,
+        "fire": 0.5759133964817321,
+        "water": 0.8398034398034399,
+        "wind": 0.18768378474233097,
+        "earth": 0.16019656019656017
       }
     },
     {
@@ -1792,6 +2056,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.21056511056511057,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.21056511056511057,
+        "fire": 0.7442489851150202,
+        "water": 0.7894348894348895,
+        "wind": 0.39738357867894963,
+        "earth": 0.21056511056511057
       }
     },
     {
@@ -1870,6 +2146,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.25257985257985255,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.25257985257985255,
+        "fire": 0.7837618403247631,
+        "water": 0.7474201474201474,
+        "wind": 0.3236856164168316,
+        "earth": 0.25257985257985255
       }
     },
     {
@@ -1948,6 +2236,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.27027027027027023,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.27027027027027023,
+        "fire": 0.6576454668470907,
+        "water": 0.7297297297297298,
+        "wind": 0.23793810915522992,
+        "earth": 0.27027027027027023
       }
     },
     {
@@ -2026,6 +2326,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.30589680589680585,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.30589680589680585,
+        "fire": 0.7055480378890392,
+        "water": 0.6941031941031941,
+        "wind": 0.4532496509492832,
+        "earth": 0.30589680589680585
       }
     },
     {
@@ -2104,6 +2416,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.3049140049140049,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.3049140049140049,
+        "fire": 0.6054127198917456,
+        "water": 0.6950859950859951,
+        "wind": 0.49504594899145665,
+        "earth": 0.3049140049140049
       }
     },
     {
@@ -2182,6 +2506,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.2954054054054054,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.2954054054054054,
+        "fire": 0.4947361299052774,
+        "water": 0.7045945945945946,
+        "wind": 0.24350496302980512,
+        "earth": 0.2954054054054054
       }
     },
     {
@@ -2260,6 +2596,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.2577395577395577,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.2577395577395577,
+        "fire": 0.33421650879566983,
+        "water": 0.7422604422604423,
+        "wind": 0.5650446470659537,
+        "earth": 0.2577395577395577
       }
     },
     {
@@ -2338,6 +2686,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.2125307125307125,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.2125307125307125,
+        "fire": 0.1608173207036536,
+        "water": 0.7874692874692875,
+        "wind": -0.30527908344444593,
+        "earth": 0.2125307125307125
       }
     },
     {
@@ -2416,6 +2776,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.17960687960687957,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.17960687960687957,
+        "fire": 0.11630541271989174,
+        "water": 0.8203931203931204,
+        "wind": 0.16630078070636192,
+        "earth": 0.17960687960687957
       }
     },
     {
@@ -2494,6 +2866,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.18095823095823096,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.18095823095823096,
+        "fire": 0.13669282814614342,
+        "water": 0.8190417690417691,
+        "wind": 0.48170525304493433,
+        "earth": 0.18095823095823096
       }
     },
     {
@@ -2572,6 +2956,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.04742014742014741,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.04742014742014741,
+        "fire": 0.0816508795669824,
+        "water": 0.9525798525798526,
+        "wind": 0.20429006900205166,
+        "earth": 0.04742014742014741
       }
     },
     {
@@ -2650,6 +3046,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.08624078624078622,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.08624078624078622,
+        "fire": 0.2706359945872801,
+        "water": 0.9137592137592138,
+        "wind": 0.06264506368211469,
+        "earth": 0.08624078624078622
       }
     },
     {
@@ -2728,6 +3136,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1514004914004914,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1514004914004914,
+        "fire": 0.3228687415426252,
+        "water": 0.8485995085995086,
+        "wind": 0.23793810915522992,
+        "earth": 0.1514004914004914
       }
     },
     {
@@ -2806,6 +3226,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1663390663390663,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1663390663390663,
+        "fire": 0.2890392422192152,
+        "water": 0.8336609336609337,
+        "wind": 0.24691690572712538,
+        "earth": 0.1663390663390663
       }
     },
     {
@@ -2884,6 +3316,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1663390663390663,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1663390663390663,
+        "fire": 0.3269282814614344,
+        "water": 0.8336609336609337,
+        "wind": 0.4175140405931393,
+        "earth": 0.1663390663390663
       }
     },
     {
@@ -2962,6 +3406,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.17223587223587222,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.17223587223587222,
+        "fire": 0.3510148849797023,
+        "water": 0.8277641277641278,
+        "wind": 0.8299550611231576,
+        "earth": 0.17223587223587222
       }
     },
     {
@@ -3040,6 +3496,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.17837837837837836,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.17837837837837836,
+        "fire": 0.35588633288227334,
+        "water": 0.8216216216216217,
+        "wind": 0.05589300866004929,
+        "earth": 0.17837837837837836
       }
     },
     {
@@ -3118,6 +3586,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.18476658476658475,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.18476658476658475,
+        "fire": 0.36400541271989173,
+        "water": 0.8152334152334153,
+        "wind": 0.07016929520936309,
+        "earth": 0.18476658476658475
       }
     },
     {
@@ -3196,6 +3676,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.12933660933660934,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.12933660933660934,
+        "fire": 0.29742895805142083,
+        "water": 0.8706633906633907,
+        "wind": 0.05028126080261462,
+        "earth": 0.12933660933660934
       }
     },
     {
@@ -3274,6 +3766,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.1941031941031941,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.1941031941031941,
+        "fire": 0.428958051420839,
+        "water": 0.8058968058968059,
+        "wind": 0.05934984534022905,
+        "earth": 0.1941031941031941
       }
     },
     {
@@ -3352,6 +3856,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.2022113022113022,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.2022113022113022,
+        "fire": 0.4408660351826793,
+        "water": 0.7977886977886978,
+        "wind": 0.5046083673405254,
+        "earth": 0.2022113022113022
       }
     },
     {
@@ -3430,6 +3946,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.20982800982800978,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.20982800982800978,
+        "fire": 0.4546684709066306,
+        "water": 0.7901719901719902,
+        "wind": 0.15245996579078505,
+        "earth": 0.20982800982800978
       }
     },
     {
@@ -3508,6 +4036,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.21597051597051595,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.21597051597051595,
+        "fire": 0.46928281461434374,
+        "water": 0.784029484029484,
+        "wind": 0.14639927810475561,
+        "earth": 0.21597051597051595
       }
     },
     {
@@ -3586,6 +4126,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.22275184275184276,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.22275184275184276,
+        "fire": 0.48768606224627875,
+        "water": 0.7772481572481572,
+        "wind": 0.1351308884070268,
+        "earth": 0.22275184275184276
       }
     },
     {
@@ -3664,6 +4216,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.22899262899262898,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.22899262899262898,
+        "fire": 0.4920162381596752,
+        "water": 0.771007371007371,
+        "wind": 0.4444504303088257,
+        "earth": 0.22899262899262898
       }
     },
     {
@@ -3742,6 +4306,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.16953316953316952,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.16953316953316952,
+        "fire": 0.2968876860622463,
+        "water": 0.8304668304668305,
+        "wind": -0.008664538691879126,
+        "earth": 0.16953316953316952
       }
     },
     {
@@ -3820,6 +4396,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.24179361179361175,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.24179361179361175,
+        "fire": 0.5209742895805142,
+        "water": 0.7582063882063883,
+        "wind": 0.1499459027506543,
+        "earth": 0.24179361179361175
       }
     },
     {
@@ -3898,6 +4486,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.327027027027027,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.327027027027027,
+        "fire": 0.6782138024357239,
+        "water": 0.672972972972973,
+        "wind": 0.07712786255258207,
+        "earth": 0.327027027027027
       }
     },
     {
@@ -3976,6 +4576,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.4100737100737101,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.4100737100737101,
+        "fire": 0.8903924221921515,
+        "water": 0.5899262899262899,
+        "wind": 0.13917134686437976,
+        "earth": 0.4100737100737101
       }
     },
     {
@@ -4054,6 +4666,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.4729729729729729,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.4729729729729729,
+        "fire": 1,
+        "water": 0.5270270270270271,
+        "wind": 0.35358500900124357,
+        "earth": 0.4729729729729729
       }
     },
     {
@@ -4132,6 +4756,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.5164619164619164,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.5164619164619164,
+        "fire": 0.9361299052774019,
+        "water": 0.4835380835380836,
+        "wind": 0.026161070631703233,
+        "earth": 0.5164619164619164
       }
     },
     {
@@ -4210,6 +4846,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.555036855036855,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.555036855036855,
+        "fire": 0.894722598105548,
+        "water": 0.44496314496314504,
+        "wind": 0.46685252775570485,
+        "earth": 0.555036855036855
       }
     },
     {
@@ -4288,6 +4936,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.5542997542997542,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.5542997542997542,
+        "fire": 0.7358592692828146,
+        "water": 0.4457002457002458,
+        "wind": 0.677629777280951,
+        "earth": 0.5542997542997542
       }
     },
     {
@@ -4366,6 +5026,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.527027027027027,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.527027027027027,
+        "fire": 0.5524763193504736,
+        "water": 0.472972972972973,
+        "wind": 0.9205107139490093,
+        "earth": 0.527027027027027
       }
     },
     {
@@ -4444,6 +5116,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.4742014742014742,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.4742014742014742,
+        "fire": 0.36192963464140726,
+        "water": 0.5257985257985258,
+        "wind": 1,
+        "earth": 0.4742014742014742
       }
     },
     {
@@ -4522,6 +5206,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.33253071253071254,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.33253071253071254,
+        "fire": 0.06341569688768606,
+        "water": 0.6674692874692875,
+        "wind": -0.21549111772549123,
+        "earth": 0.33253071253071254
       }
     },
     {
@@ -4600,6 +5296,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.29115479115479115,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.29115479115479115,
+        "fire": 0.15615696887686062,
+        "water": 0.7088452088452089,
+        "wind": 0.1634140976084975,
+        "earth": 0.29115479115479115
       }
     },
     {
@@ -4678,6 +5386,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.2786240786240786,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.2786240786240786,
+        "fire": 0.1625466847090663,
+        "water": 0.7213759213759214,
+        "wind": 0.1545268847616354,
+        "earth": 0.2786240786240786
       }
     },
     {
@@ -4756,6 +5476,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.24029484029484027,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.24029484029484027,
+        "fire": 0.1474154262516915,
+        "water": 0.7597051597051597,
+        "wind": 0.4081940497515118,
+        "earth": 0.24029484029484027
       }
     },
     {
@@ -4834,6 +5566,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.22594594594594591,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.22594594594594591,
+        "fire": 0.14262516914749662,
+        "water": 0.7740540540540541,
+        "wind": 0.6105581668888919,
+        "earth": 0.22594594594594591
       }
     },
     {
@@ -4912,6 +5656,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.04594594594594595,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.04594594594594595,
+        "fire": 0.08119079837618404,
+        "water": 0.9540540540540541,
+        "wind": 0.21050788562808925,
+        "earth": 0.04594594594594595
       }
     },
     {
@@ -4990,6 +5746,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.13513513513513511,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.13513513513513511,
+        "fire": 0.3336941813261164,
+        "water": 0.8648648648648649,
+        "wind": 0.043315959361966715,
+        "earth": 0.13513513513513511
       }
     },
     {
@@ -5068,6 +5836,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.24570024570024568,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.24570024570024568,
+        "fire": 0.4059539918809202,
+        "water": 0.7542997542997543,
+        "wind": 0.151606980116455,
+        "earth": 0.24570024570024568
       }
     },
     {
@@ -5146,6 +5926,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.288058968058968,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.288058968058968,
+        "fire": 0.5474966170500677,
+        "water": 0.711941031941032,
+        "wind": 0.5060449747920286,
+        "earth": 0.288058968058968
       }
     },
     {
@@ -5224,6 +6016,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.3776412776412776,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.3776412776412776,
+        "fire": 0.4982408660351827,
+        "water": 0.6223587223587224,
+        "wind": 0.23807279110380836,
+        "earth": 0.3776412776412776
       }
     },
     {
@@ -5302,6 +6106,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.4692874692874693,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.4692874692874693,
+        "fire": 0.3803247631935047,
+        "water": 0.5307125307125307,
+        "wind": 0.22868994868617756,
+        "earth": 0.4692874692874693
       }
     },
     {
@@ -5380,6 +6196,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.5024570024570024,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.5024570024570024,
+        "fire": 0.24682002706359946,
+        "water": 0.4975429975429976,
+        "wind": 0.20583891141070362,
+        "earth": 0.5024570024570024
       }
     },
     {
@@ -5458,6 +6286,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.4868796068796068,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.4868796068796068,
+        "fire": 0.2469553450608931,
+        "water": 0.5131203931203931,
+        "wind": -0.216972619159854,
+        "earth": 0.4868796068796068
       }
     },
     {
@@ -5536,6 +6376,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.29484029484029484,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.29484029484029484,
+        "fire": 0.3921515561569689,
+        "water": 0.7051597051597052,
+        "wind": 0.044579724979461,
+        "earth": 0.29484029484029484
       }
     },
     {
@@ -5614,6 +6466,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.3319410319410319,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.3319410319410319,
+        "fire": 0.4365358592692828,
+        "water": 0.6680589680589681,
+        "wind": 0.12197695142919994,
+        "earth": 0.3319410319410319
       }
     },
     {
@@ -5692,6 +6556,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.3631449631449631,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.3631449631449631,
+        "fire": 0.34073071718538567,
+        "water": 0.636855036855037,
+        "wind": -0.7418281727700037,
+        "earth": 0.3631449631449631
       }
     },
     {
@@ -5770,6 +6646,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.37100737100737097,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.37100737100737097,
+        "fire": 0.31745602165087955,
+        "water": 0.6289926289926291,
+        "wind": -0.436863347205574,
+        "earth": 0.37100737100737097
       }
     },
     {
@@ -5848,6 +6736,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.21719901719901719,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.21719901719901719,
+        "fire": 0.30663058186738834,
+        "water": 0.7828009828009828,
+        "wind": -0.1283967909781052,
+        "earth": 0.21719901719901719
       }
     },
     {
@@ -5926,6 +6826,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0.4871447902571042,
+        "water": 1,
+        "wind": 0.15245996579078505,
+        "earth": 0
       }
     },
     {
@@ -6004,6 +6916,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0.2976995940460081,
+        "water": 1,
+        "wind": 0.4215993930333517,
+        "earth": 0
       }
     },
     {
@@ -6082,6 +7006,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0.2976995940460081,
+        "water": 1,
+        "wind": -1.002123485389253,
+        "earth": 0
       }
     },
     {
@@ -6160,6 +7096,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0.5142083897158322,
+        "water": 1,
+        "wind": -0.13486152450986993,
+        "earth": 0
       }
     },
     {
@@ -6238,6 +7186,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.57002457002457,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.57002457002457,
+        "fire": 0.6495263870094723,
+        "water": 0.42997542997543003,
+        "wind": 0,
+        "earth": 0.57002457002457
       }
     },
     {
@@ -6316,6 +7276,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.7199017199017199,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.7199017199017199,
+        "fire": 0,
+        "water": 0.2800982800982801,
+        "wind": 0,
+        "earth": 0.7199017199017199
       }
     },
     {
@@ -6394,6 +7366,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.8599508599508598,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.8599508599508598,
+        "fire": 0,
+        "water": 0.14004914004914015,
+        "wind": 0,
+        "earth": 0.8599508599508598
       }
     },
     {
@@ -6472,6 +7456,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.9115479115479115,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.9115479115479115,
+        "fire": 0,
+        "water": 0.08845208845208852,
+        "wind": 0,
+        "earth": 0.9115479115479115
       }
     },
     {
@@ -6550,6 +7546,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 1,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 1,
+        "fire": 0.03410013531799729,
+        "water": 0,
+        "wind": 0,
+        "earth": 1
       }
     },
     {
@@ -6628,6 +7636,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.9189189189189189,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.9189189189189189,
+        "fire": 0,
+        "water": 0.08108108108108114,
+        "wind": 0,
+        "earth": 0.9189189189189189
       }
     },
     {
@@ -6706,6 +7726,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.8550368550368549,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.8550368550368549,
+        "fire": 0,
+        "water": 0.1449631449631451,
+        "wind": 0,
+        "earth": 0.8550368550368549
       }
     },
     {
@@ -6784,6 +7816,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.705159705159705,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.705159705159705,
+        "fire": 0,
+        "water": 0.29484029484029495,
+        "wind": 0.6778991411781079,
+        "earth": 0.705159705159705
       }
     },
     {
@@ -6791,7 +7835,7 @@
       "atomic_mass": 285,
       "boil": 3570,
       "category": "transition metal",
-      "density": 14.0,
+      "density": 14,
       "melt": null,
       "molar_heat": null,
       "symbol": "Cn",
@@ -6862,6 +7906,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.34398034398034394,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.34398034398034394,
+        "fire": 0,
+        "water": 0.6560196560196561,
+        "wind": 0,
+        "earth": 0.34398034398034394
       }
     },
     {
@@ -6940,6 +7996,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.3931203931203931,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.3931203931203931,
+        "fire": 0.18944519621109607,
+        "water": 0.606879606879607,
+        "wind": 0.29899392584411905,
+        "earth": 0.3931203931203931
       }
     },
     {
@@ -7018,6 +8086,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.34398034398034394,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.34398034398034394,
+        "fire": 0.09201623815967523,
+        "water": 0.6560196560196561,
+        "wind": 0,
+        "earth": 0.34398034398034394
       }
     },
     {
@@ -7096,6 +8176,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.33169533169533166,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.33169533169533166,
+        "fire": 0.18132611637347767,
+        "water": 0.6683046683046683,
+        "wind": 0.158475759493955,
+        "earth": 0.33169533169533166
       }
     },
     {
@@ -7174,6 +8266,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.31695331695331697,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.31695331695331697,
+        "fire": 0.1918809201623816,
+        "water": 0.683046683046683,
+        "wind": 0.3362559316174853,
+        "earth": 0.31695331695331697
       }
     },
     {
@@ -7252,6 +8356,18 @@
           "value": null,
           "units": "cm³/mol"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0.07371007371007371,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0.07371007371007371,
+        "fire": 0,
+        "water": 0.9262899262899262,
+        "wind": 0.28673786852348176,
+        "earth": 0.07371007371007371
       }
     }
   ]

--- a/public/Master_Metal_Alloys.json
+++ b/public/Master_Metal_Alloys.json
@@ -18,7 +18,7 @@
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 530.0
+          "value": 530
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -42,7 +42,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 556.0
+          "value": 556
         },
         "boiling_point": {
           "units": "degC",
@@ -73,7 +73,7 @@
           "value": 51.5
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -88,6 +88,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.29419999999999996,
+        "pierce": 0.5257510729613734,
+        "blunt": 0.06904176904176904,
+        "defense_slash": 0.5435897435897435,
+        "defense_pierce": 0.29419999999999996,
+        "defense_blunt": 0.06904176904176904,
+        "fire": 0,
+        "water": 0.9309582309582309,
+        "wind": 0,
+        "earth": 0.06904176904176904
       }
     },
     {
@@ -128,7 +140,7 @@
         },
         "density": {
           "units": "g/cm3",
-          "value": 8.0
+          "value": 8
         },
         "melting_point": {
           "units": "degC",
@@ -144,7 +156,7 @@
         },
         "thermal_expansion_coefficient": {
           "units": "um/m*K",
-          "value": 16.0
+          "value": 16
         },
         "specific_heat": {
           "units": "J/g*K",
@@ -160,10 +172,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 740.0
+          "value": 740
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -178,6 +190,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.39672363636363633,
+        "pierce": 0.4871244635193133,
+        "blunt": 0.19656019656019655,
+        "defense_slash": 0.25384615384615383,
+        "defense_pierce": 0.39672363636363633,
+        "defense_blunt": 0.19656019656019655,
+        "fire": 0,
+        "water": 0.8034398034398035,
+        "wind": 0,
+        "earth": 0.19656019656019655
       }
     },
     {
@@ -194,7 +218,7 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 550.0
+          "value": 550
         },
         "yield_strength": {
           "units": "MPa",
@@ -234,7 +258,7 @@
         },
         "thermal_expansion_coefficient": {
           "units": "um/m*K",
-          "value": 12.0
+          "value": 12
         },
         "specific_heat": {
           "units": "J/g*K",
@@ -250,10 +274,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 167.0
+          "value": 167
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -268,6 +292,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.3209454545454546,
+        "pierce": 0.4721030042918455,
+        "blunt": 0.19287469287469286,
+        "defense_slash": 0.43333333333333335,
+        "defense_pierce": 0.3209454545454546,
+        "defense_blunt": 0.19287469287469286,
+        "fire": 0,
+        "water": 0.8071253071253072,
+        "wind": 0,
+        "earth": 0.19287469287469286
       }
     },
     {
@@ -284,11 +320,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 925.0
+          "value": 925
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 750.0
+          "value": 750
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -324,7 +360,7 @@
         },
         "thermal_expansion_coefficient": {
           "units": "um/m*K",
-          "value": 12.0
+          "value": 12
         },
         "specific_heat": {
           "units": "J/g*K",
@@ -340,10 +376,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 248.0
+          "value": 248
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -358,6 +394,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.5170781818181818,
+        "pierce": 0.7939914163090128,
+        "blunt": 0.19287469287469286,
+        "defense_slash": 0.7692307692307693,
+        "defense_pierce": 0.5170781818181818,
+        "defense_blunt": 0.19287469287469286,
+        "fire": 0,
+        "water": 0.8071253071253072,
+        "wind": 0,
+        "earth": 0.19287469287469286
       }
     },
     {
@@ -374,15 +422,15 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 230.0
+          "value": 230
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 85.0
+          "value": 85
         },
         "youngs_modulus": {
           "units": "GPa",
-          "value": 119.0
+          "value": 119
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -433,7 +481,7 @@
           "value": 17.2
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -448,6 +496,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.10698181818181816,
+        "pierce": 0.19742489270386265,
+        "blunt": 0.21965601965601964,
+        "defense_slash": 0.08717948717948718,
+        "defense_pierce": 0.10698181818181816,
+        "defense_blunt": 0.21965601965601964,
+        "fire": 0,
+        "water": 0.7803439803439803,
+        "wind": 0,
+        "earth": 0.21965601965601964
       }
     },
     {
@@ -464,11 +524,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 425.0
+          "value": 425
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 300.0
+          "value": 300
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -492,7 +552,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 895.0
+          "value": 895
         },
         "boiling_point": {
           "units": "degC",
@@ -523,7 +583,7 @@
           "value": 64.9
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -538,6 +598,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.17830181818181817,
+        "pierce": 0.3648068669527897,
+        "blunt": 0.20810810810810812,
+        "defense_slash": 0.3076923076923077,
+        "defense_pierce": 0.17830181818181817,
+        "defense_blunt": 0.20810810810810812,
+        "fire": 0,
+        "water": 0.7918918918918919,
+        "wind": 0,
+        "earth": 0.20810810810810812
       }
     },
     {
@@ -554,11 +626,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 500.0
+          "value": 500
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 260.0
+          "value": 260
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -594,7 +666,7 @@
         },
         "thermal_expansion_coefficient": {
           "units": "um/m*K",
-          "value": 18.0
+          "value": 18
         },
         "specific_heat": {
           "units": "J/g*K",
@@ -610,10 +682,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 135.0
+          "value": 135
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -628,6 +700,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.24962363636363635,
+        "pierce": 0.4291845493562232,
+        "blunt": 0.21621621621621623,
+        "defense_slash": 0.26666666666666666,
+        "defense_pierce": 0.24962363636363635,
+        "defense_blunt": 0.21621621621621623,
+        "fire": 0,
+        "water": 0.7837837837837838,
+        "wind": 0,
+        "earth": 0.21621621621621623
       }
     },
     {
@@ -644,11 +728,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 930.0
+          "value": 930
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 467.0
+          "value": 467
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -672,7 +756,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1320.0
+          "value": 1320
         },
         "boiling_point": {
           "units": "degC",
@@ -700,10 +784,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 1020.0
+          "value": 1020
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -718,6 +802,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.39672363636363633,
+        "pierce": 0.7982832618025751,
+        "blunt": 0.20737100737100733,
+        "defense_slash": 0.47897435897435897,
+        "defense_pierce": 0.39672363636363633,
+        "defense_blunt": 0.20737100737100733,
+        "fire": 0,
+        "water": 0.7926289926289927,
+        "wind": 0,
+        "earth": 0.20737100737100733
       }
     },
     {
@@ -734,11 +830,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 1080.0
+          "value": 1080
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 790.0
+          "value": 790
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -762,7 +858,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1300.0
+          "value": 1300
         },
         "boiling_point": {
           "units": "degC",
@@ -790,10 +886,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 862.0
+          "value": 862
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -808,6 +904,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.5081636363636364,
+        "pierce": 0.927038626609442,
+        "blunt": 0.2012285012285012,
+        "defense_slash": 0.8102564102564103,
+        "defense_pierce": 0.5081636363636364,
+        "defense_blunt": 0.2012285012285012,
+        "fire": 0,
+        "water": 0.7987714987714988,
+        "wind": 0,
+        "earth": 0.2012285012285012
       }
     },
     {
@@ -824,15 +932,15 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 550.0
+          "value": 550
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 190.0
+          "value": 190
         },
         "youngs_modulus": {
           "units": "GPa",
-          "value": 185.0
+          "value": 185
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -852,7 +960,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1325.0
+          "value": 1325
         },
         "boiling_point": {
           "units": "degC",
@@ -880,10 +988,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 455.0
+          "value": 455
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -898,6 +1006,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.3120290909090909,
+        "pierce": 0.4721030042918455,
+        "blunt": 0.21621621621621623,
+        "defense_slash": 0.19487179487179487,
+        "defense_pierce": 0.3120290909090909,
+        "defense_blunt": 0.21621621621621623,
+        "fire": 0,
+        "water": 0.7837837837837838,
+        "wind": 0,
+        "earth": 0.21621621621621623
       }
     },
     {
@@ -914,7 +1034,7 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 740.0
+          "value": 740
         },
         "yield_strength": {
           "units": "MPa",
@@ -970,10 +1090,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 909.0
+          "value": 909
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -988,6 +1108,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.4011818181818182,
+        "pierce": 0.6351931330472103,
+        "blunt": 0.21842751842751842,
+        "defense_slash": 0.33589743589743587,
+        "defense_pierce": 0.4011818181818182,
+        "defense_blunt": 0.21842751842751842,
+        "fire": 0,
+        "water": 0.7815724815724816,
+        "wind": 0,
+        "earth": 0.21842751842751842
       }
     },
     {
@@ -1004,11 +1136,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 265.0
+          "value": 265
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 160.0
+          "value": 160
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -1032,7 +1164,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 635.0
+          "value": 635
         },
         "boiling_point": {
           "units": "degC",
@@ -1060,10 +1192,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 455.0
+          "value": 455
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1078,6 +1210,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.11143999999999998,
+        "pierce": 0.22746781115879827,
+        "blunt": 0.04373464373464373,
+        "defense_slash": 0.1641025641025641,
+        "defense_pierce": 0.11143999999999998,
+        "defense_blunt": 0.04373464373464373,
+        "fire": 0,
+        "water": 0.9562653562653562,
+        "wind": 0,
+        "earth": 0.04373464373464373
       }
     },
     {
@@ -1098,7 +1242,7 @@
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 245.0
+          "value": 245
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -1122,7 +1266,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1425.0
+          "value": 1425
         },
         "boiling_point": {
           "units": "degC",
@@ -1150,10 +1294,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 690.0
+          "value": 690
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1168,6 +1312,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.32986,
+        "pierce": 0.5429184549356223,
+        "blunt": 0.19484029484029483,
+        "defense_slash": 0.2512820512820513,
+        "defense_pierce": 0.32986,
+        "defense_blunt": 0.19484029484029483,
+        "fire": 0,
+        "water": 0.8051597051597051,
+        "wind": 0,
+        "earth": 0.19484029484029483
       }
     },
     {
@@ -1184,7 +1340,7 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 495.0
+          "value": 495
         },
         "yield_strength": {
           "units": "MPa",
@@ -1212,7 +1368,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 570.0
+          "value": 570
         },
         "boiling_point": {
           "units": "degC",
@@ -1243,7 +1399,7 @@
           "value": 58.1
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1258,6 +1414,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.2540818181818182,
+        "pierce": 0.4248927038626609,
+        "blunt": 0.06830466830466829,
+        "defense_slash": 0.3769230769230769,
+        "defense_pierce": 0.2540818181818182,
+        "defense_blunt": 0.06830466830466829,
+        "fire": 0,
+        "water": 0.9316953316953317,
+        "wind": 0,
+        "earth": 0.06830466830466829
       }
     },
     {
@@ -1274,11 +1442,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 1165.0
+          "value": 1165
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 975.0
+          "value": 975
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -1302,7 +1470,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1425.0
+          "value": 1425
         },
         "boiling_point": {
           "units": "degC",
@@ -1330,10 +1498,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 833.0
+          "value": 833
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1348,6 +1516,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.6686345454545454,
+        "pierce": 1,
+        "blunt": 0.1904176904176904,
+        "defense_slash": 1,
+        "defense_pierce": 0.6686345454545454,
+        "defense_blunt": 0.1904176904176904,
+        "fire": 0,
+        "water": 0.8095823095823096,
+        "wind": 0,
+        "earth": 0.1904176904176904
       }
     },
     {
@@ -1364,15 +1544,15 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 345.0
+          "value": 345
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 185.0
+          "value": 185
         },
         "youngs_modulus": {
           "units": "GPa",
-          "value": 105.0
+          "value": 105
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1392,7 +1572,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 975.0
+          "value": 975
         },
         "boiling_point": {
           "units": "degC",
@@ -1404,7 +1584,7 @@
         },
         "thermal_expansion_coefficient": {
           "units": "um/m*K",
-          "value": 18.0
+          "value": 18
         },
         "specific_heat": {
           "units": "J/g*K",
@@ -1420,10 +1600,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 150.0
+          "value": 150
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1438,6 +1618,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.17384545454545453,
+        "pierce": 0.296137339055794,
+        "blunt": 0.21867321867321868,
+        "defense_slash": 0.18974358974358974,
+        "defense_pierce": 0.17384545454545453,
+        "defense_blunt": 0.21867321867321868,
+        "fire": 0,
+        "water": 0.7813267813267813,
+        "wind": 0,
+        "earth": 0.21867321867321868
       }
     },
     {
@@ -1454,11 +1646,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 280.0
+          "value": 280
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 155.0
+          "value": 155
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -1482,7 +1674,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 581.0
+          "value": 581
         },
         "boiling_point": {
           "units": "degC",
@@ -1513,7 +1705,7 @@
           "value": 58.1
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1528,6 +1720,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.15601454545454546,
+        "pierce": 0.24034334763948498,
+        "blunt": 0.06535626535626536,
+        "defense_slash": 0.15897435897435896,
+        "defense_pierce": 0.15601454545454546,
+        "defense_blunt": 0.06535626535626536,
+        "fire": 0,
+        "water": 0.9346437346437346,
+        "wind": 0,
+        "earth": 0.06535626535626536
       }
     },
     {
@@ -1544,7 +1748,7 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 515.0
+          "value": 515
         },
         "yield_strength": {
           "units": "MPa",
@@ -1603,7 +1807,7 @@
           "value": 58.1
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1618,6 +1822,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.25853818181818183,
+        "pierce": 0.44206008583690987,
+        "blunt": 0.06977886977886977,
+        "defense_slash": 0.3871794871794872,
+        "defense_pierce": 0.25853818181818183,
+        "defense_blunt": 0.06977886977886977,
+        "fire": 0,
+        "water": 0.9302211302211303,
+        "wind": 0,
+        "earth": 0.06977886977886977
       }
     },
     {
@@ -1634,11 +1850,11 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 165.0
+          "value": 165
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 75.0
+          "value": 75
         },
         "youngs_modulus": {
           "units": "GPa",
@@ -1693,7 +1909,7 @@
           "value": 42.7
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1708,6 +1924,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.08915090909090909,
+        "pierce": 0.14163090128755365,
+        "blunt": 0.06707616707616706,
+        "defense_slash": 0.07692307692307693,
+        "defense_pierce": 0.08915090909090909,
+        "defense_blunt": 0.06707616707616706,
+        "fire": 0,
+        "water": 0.932923832923833,
+        "wind": 0,
+        "earth": 0.06707616707616706
       }
     },
     {
@@ -1724,15 +1952,15 @@
       "mechanical_properties": {
         "ultimate_tensile_strength": {
           "units": "MPa",
-          "value": 975.0
+          "value": 975
         },
         "yield_strength": {
           "units": "MPa",
-          "value": 725.0
+          "value": 725
         },
         "youngs_modulus": {
           "units": "GPa",
-          "value": 245.0
+          "value": 245
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1752,7 +1980,7 @@
         },
         "melting_point": {
           "units": "degC",
-          "value": 1485.0
+          "value": 1485
         },
         "boiling_point": {
           "units": "degC",
@@ -1780,10 +2008,10 @@
         },
         "electrical_resistivity": {
           "units": "nOhm*m",
-          "value": 500.0
+          "value": 500
         },
         "magnetic_susceptibility": {
-          "units": "cm\u00b3/mol",
+          "units": "cm³/mol",
           "value": "N/A"
         },
         "hardness_brinell": {
@@ -1798,6 +2026,18 @@
           "units": "J/g*K",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0.6329745454545455,
+        "pierce": 0.8369098712446352,
+        "blunt": 0.20393120393120392,
+        "defense_slash": 0.7435897435897436,
+        "defense_pierce": 0.6329745454545455,
+        "defense_blunt": 0.20393120393120392,
+        "fire": 0,
+        "water": 0.7960687960687961,
+        "wind": 0,
+        "earth": 0.20393120393120392
       }
     },
     {
@@ -1876,6 +2116,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -1954,6 +2206,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2032,6 +2296,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2110,6 +2386,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2188,6 +2476,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2266,6 +2566,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2344,6 +2656,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2422,6 +2746,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2500,6 +2836,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2578,6 +2926,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2656,6 +3016,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2734,6 +3106,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2812,6 +3196,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2890,6 +3286,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -2968,6 +3376,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3046,6 +3466,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3124,6 +3556,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3202,6 +3646,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3280,6 +3736,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3358,6 +3826,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3436,6 +3916,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3514,6 +4006,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3592,6 +4096,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3670,6 +4186,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3748,6 +4276,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3826,6 +4366,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3904,6 +4456,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -3982,6 +4546,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4060,6 +4636,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4138,6 +4726,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4216,6 +4816,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4294,6 +4906,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4372,6 +4996,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4450,6 +5086,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4528,6 +5176,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4606,6 +5266,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4684,6 +5356,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4762,6 +5446,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4840,6 +5536,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4918,6 +5626,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -4996,6 +5716,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5074,6 +5806,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5152,6 +5896,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5230,6 +5986,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5308,6 +6076,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5386,6 +6166,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5464,6 +6256,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5542,6 +6346,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5620,6 +6436,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5698,6 +6526,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5776,6 +6616,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5854,6 +6706,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -5932,6 +6796,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6010,6 +6886,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6088,6 +6976,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6166,6 +7066,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6244,6 +7156,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6322,6 +7246,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6400,6 +7336,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6478,6 +7426,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6556,6 +7516,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6634,6 +7606,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6712,6 +7696,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6790,6 +7786,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6868,6 +7876,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -6946,6 +7966,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7024,6 +8056,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7102,6 +8146,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7180,6 +8236,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7258,6 +8326,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7336,6 +8416,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7414,6 +8506,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7492,6 +8596,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7570,6 +8686,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     },
     {
@@ -7648,6 +8776,18 @@
           "units": "cm3/mol",
           "value": "N/A"
         }
+      },
+      "factors": {
+        "slash": 0,
+        "pierce": 0,
+        "blunt": 0,
+        "defense_slash": 0,
+        "defense_pierce": 0,
+        "defense_blunt": 0,
+        "fire": 0,
+        "water": 1,
+        "wind": 0,
+        "earth": 0
       }
     }
   ]

--- a/scripts/populateMetalFactors.js
+++ b/scripts/populateMetalFactors.js
@@ -1,0 +1,67 @@
+import fs from 'fs';
+
+const files = [
+  'public/Master_Elemental_Metals.json',
+  'public/Master_Metal_Alloys.json'
+];
+
+function readJSON(path){
+  return JSON.parse(fs.readFileSync(path,'utf8'));
+}
+
+function num(val){
+  if(val===null || val===undefined || val==='N/A') return 0;
+  return Number(val);
+}
+
+function hardness(mp){
+  if(!mp) return 0;
+  const mh = num(mp.mohs_hardness?.value);
+  if(mh) return mh;
+  const vh = num(mp.vickers_hardness?.value);
+  if(vh) return vh/1000;
+  const bh = num(mp.brinell_hardness?.value);
+  if(bh) return bh/1000;
+  return 0;
+}
+
+const datasets = files.map(readJSON);
+const elements = datasets.flatMap(d => d.elements);
+
+function gatherMax(fn){
+  return elements.reduce((m,el)=>Math.max(m,fn(el)),0);
+}
+
+const maxHard = gatherMax(el=>hardness(el.mechanical_properties));
+const maxTensile = gatherMax(el=>num(el.mechanical_properties?.ultimate_tensile_strength?.value));
+const maxYield = gatherMax(el=>num(el.mechanical_properties?.yield_strength?.value));
+const maxDensity = gatherMax(el=>num(el.mechanical_properties?.density?.value ?? el.density));
+const maxMelt = gatherMax(el=>num(el.melt));
+const maxEA = gatherMax(el=>num(el.electron_affinity));
+
+for(const el of elements){
+  const mp = el.mechanical_properties || {};
+  const hard = hardness(mp);
+  const tensile = num(mp.ultimate_tensile_strength?.value);
+  const yieldStrength = num(mp.yield_strength?.value);
+  const dens = num(mp.density?.value ?? el.density);
+  const melt = num(el.melt);
+  const ea = num(el.electron_affinity);
+
+  el.factors = {
+    slash: maxHard ? hard / maxHard : 0,
+    pierce: maxTensile ? tensile / maxTensile : 0,
+    blunt: maxDensity ? dens / maxDensity : 0,
+    defense_slash: maxYield ? yieldStrength / maxYield : 0,
+    defense_pierce: maxHard ? hard / maxHard : 0,
+    defense_blunt: maxDensity ? dens / maxDensity : 0,
+    fire: maxMelt ? melt / maxMelt : 0,
+    water: maxDensity ? 1 - dens / maxDensity : 0,
+    wind: maxEA ? ea / maxEA : 0,
+    earth: maxDensity ? dens / maxDensity : 0
+  };
+}
+
+datasets.forEach((data,i)=>{
+  fs.writeFileSync(files[i], JSON.stringify(data, null, 2)+"\n");
+});


### PR DESCRIPTION
## Summary
- compute normalized offensive and defensive factors for metals based on available mechanical properties
- populate elemental and alloy metal data files with the calculated factors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aca9c66280833094ed478b7f7ed04d