### PR TITLE
Fix armor piece dropdown in crafting calculator

### DIFF
--- a/public/Master_Elemental_Metals.json
+++ b/public/Master_Elemental_Metals.json
@@ -17,7 +17,7 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
@@ -33,7 +33,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 600,
           "units": "MPa"
         },
         "density": {
@@ -78,11 +78,11 @@
         }
       },
       "factors": {
-        "slash": 0.10909090909090909,
+        "slash": 0.163154760448023,
         "pierce": 0,
         "blunt": 0.013144963144963145,
         "defense_slash": 0,
-        "defense_pierce": 0.10909090909090909,
+        "defense_pierce": 0.163154760448023,
         "defense_blunt": 0.013144963144963145,
         "fire": 0.12277401894451961,
         "water": 0.9868550368550368,
@@ -107,7 +107,7 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
@@ -168,11 +168,11 @@
         }
       },
       "factors": {
-        "slash": 1,
+        "slash": 0.4541140832469973,
         "pierce": 0,
         "blunt": 0.04540540540540541,
         "defense_slash": 0,
-        "defense_pierce": 1,
+        "defense_pierce": 0.4541140832469973,
         "defense_blunt": 0.04540540540540541,
         "fire": 0.42219215155615697,
         "water": 0.9545945945945946,
@@ -197,7 +197,7 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
@@ -213,7 +213,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0.69,
           "units": "MPa"
         },
         "density": {
@@ -258,11 +258,11 @@
         }
       },
       "factors": {
-        "slash": 0.09090909090909091,
+        "slash": 0.0001876279745152264,
         "pierce": 0,
         "blunt": 0.02378378378378378,
         "defense_slash": 0,
-        "defense_pierce": 0.09090909090909091,
+        "defense_pierce": 0.0001876279745152264,
         "defense_blunt": 0.02378378378378378,
         "fire": 0.10039079837618403,
         "water": 0.9762162162162162,
@@ -287,11 +287,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -303,7 +303,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -377,11 +377,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -393,7 +393,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -467,11 +467,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -483,7 +483,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -557,11 +557,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -573,7 +573,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -647,11 +647,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -663,7 +663,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -737,11 +737,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -753,7 +753,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -827,11 +827,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -843,7 +843,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -917,11 +917,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -933,7 +933,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1007,11 +1007,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1023,7 +1023,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1158,11 +1158,11 @@
         }
       },
       "factors": {
-        "slash": 0.7272727272727273,
+        "slash": 0.16533015725399663,
         "pierce": 0.31759656652360513,
         "blunt": 0.19346437346437345,
         "defense_slash": 0.17435897435897435,
-        "defense_pierce": 0.7272727272727273,
+        "defense_pierce": 0.16533015725399663,
         "defense_blunt": 0.19346437346437345,
         "fire": 0.4901217861975643,
         "water": 0.8065356265356265,
@@ -1187,11 +1187,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1203,7 +1203,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1277,11 +1277,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1293,7 +1293,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1428,11 +1428,11 @@
         }
       },
       "factors": {
-        "slash": 0.5454545454545454,
+        "slash": 0.09517361026134674,
         "pierce": 0.18025751072961374,
         "blunt": 0.21916461916461916,
         "defense_slash": 0.033846153846153845,
-        "defense_pierce": 0.5454545454545454,
+        "defense_pierce": 0.09517361026134674,
         "defense_blunt": 0.21916461916461916,
         "fire": 0.36746143437077133,
         "water": 0.7808353808353808,
@@ -1457,11 +1457,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1473,7 +1473,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1547,11 +1547,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1563,7 +1563,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1637,11 +1637,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1653,7 +1653,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1727,11 +1727,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1743,7 +1743,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1817,11 +1817,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1833,7 +1833,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1907,11 +1907,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -1923,7 +1923,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -1997,11 +1997,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2013,7 +2013,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2087,11 +2087,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2103,7 +2103,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2177,11 +2177,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2193,7 +2193,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2267,11 +2267,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2283,7 +2283,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2357,11 +2357,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2373,7 +2373,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2447,11 +2447,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2463,7 +2463,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2537,11 +2537,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2553,7 +2553,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2627,11 +2627,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2643,7 +2643,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2717,11 +2717,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2733,7 +2733,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2807,11 +2807,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2823,7 +2823,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2897,11 +2897,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -2913,7 +2913,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -2987,11 +2987,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3003,7 +3003,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3077,11 +3077,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3093,7 +3093,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3167,11 +3167,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3183,7 +3183,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3257,11 +3257,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3273,7 +3273,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3347,11 +3347,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3363,7 +3363,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3437,11 +3437,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3453,7 +3453,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3527,11 +3527,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3543,7 +3543,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3617,11 +3617,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3633,7 +3633,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3707,11 +3707,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3723,7 +3723,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3797,11 +3797,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3813,7 +3813,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3887,11 +3887,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3903,7 +3903,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -3977,11 +3977,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -3993,7 +3993,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4067,11 +4067,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4083,7 +4083,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4157,11 +4157,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4173,7 +4173,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4247,11 +4247,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4263,7 +4263,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4337,11 +4337,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4353,7 +4353,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4427,11 +4427,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4443,7 +4443,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4517,11 +4517,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4533,7 +4533,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4607,11 +4607,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4623,7 +4623,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4697,11 +4697,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4713,7 +4713,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4787,11 +4787,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4803,7 +4803,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4877,11 +4877,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4893,7 +4893,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -4967,11 +4967,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -4983,7 +4983,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5057,11 +5057,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5073,7 +5073,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5147,11 +5147,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5163,7 +5163,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5237,11 +5237,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5253,7 +5253,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5327,11 +5327,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5343,7 +5343,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5417,11 +5417,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5433,7 +5433,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5507,11 +5507,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5523,7 +5523,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5597,11 +5597,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5613,7 +5613,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5687,11 +5687,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5703,7 +5703,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5777,11 +5777,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5793,7 +5793,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5867,11 +5867,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5883,7 +5883,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -5957,11 +5957,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -5973,7 +5973,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6047,11 +6047,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6063,7 +6063,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6137,11 +6137,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6153,7 +6153,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6227,11 +6227,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6243,7 +6243,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6317,11 +6317,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6333,7 +6333,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6407,11 +6407,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6423,7 +6423,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6497,11 +6497,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6513,7 +6513,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6587,11 +6587,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6603,7 +6603,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6677,11 +6677,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6693,7 +6693,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6767,11 +6767,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6783,7 +6783,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6857,11 +6857,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6873,7 +6873,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -6947,11 +6947,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -6963,7 +6963,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7037,11 +7037,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7053,7 +7053,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7127,11 +7127,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7143,7 +7143,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7217,11 +7217,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7233,7 +7233,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7307,11 +7307,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7323,7 +7323,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7397,11 +7397,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7413,7 +7413,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7487,11 +7487,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7503,7 +7503,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7577,11 +7577,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7593,7 +7593,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7667,11 +7667,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7683,7 +7683,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7757,11 +7757,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7773,7 +7773,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7847,11 +7847,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7863,7 +7863,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -7937,11 +7937,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -7953,7 +7953,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -8027,11 +8027,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -8043,7 +8043,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -8117,11 +8117,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -8133,7 +8133,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -8207,11 +8207,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -8223,7 +8223,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {
@@ -8297,11 +8297,11 @@
           "units": "MPa"
         },
         "yield_strength": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "youngs_modulus": {
-          "value": null,
+          "value": 0,
           "units": "GPa"
         },
         "mohs_hardness": {
@@ -8313,7 +8313,7 @@
           "units": "MPa"
         },
         "vickers_hardness": {
-          "value": null,
+          "value": 0,
           "units": "MPa"
         },
         "density": {

--- a/public/Master_Metal_Alloys.json
+++ b/public/Master_Metal_Alloys.json
@@ -17,12 +17,12 @@
           "value": 612.5
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 530
+          "value": 530,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 71
+          "value": 71,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -33,8 +33,8 @@
           "value": 1520.03
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1618.1
+          "value": 1618.1,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -90,11 +90,11 @@
         }
       },
       "factors": {
-        "slash": 0.29419999999999996,
+        "slash": 0.44000119646824326,
         "pierce": 0.5257510729613734,
         "blunt": 0.06904176904176904,
         "defense_slash": 0.5435897435897435,
-        "defense_pierce": 0.29419999999999996,
+        "defense_pierce": 0.44000119646824326,
         "defense_blunt": 0.06904176904176904,
         "fire": 0,
         "water": 0.9309582309582309,
@@ -119,12 +119,12 @@
           "value": 567.5
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 247.5
+          "value": 247.5,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 193
+          "value": 193,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -135,8 +135,8 @@
           "value": 1794.62
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 2181.98
+          "value": 2181.98,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -192,11 +192,11 @@
         }
       },
       "factors": {
-        "slash": 0.39672363636363633,
+        "slash": 0.5933340403372953,
         "pierce": 0.4871244635193133,
         "blunt": 0.19656019656019655,
         "defense_slash": 0.25384615384615383,
-        "defense_pierce": 0.39672363636363633,
+        "defense_pierce": 0.5933340403372953,
         "defense_blunt": 0.19656019656019655,
         "fire": 0,
         "water": 0.8034398034398035,
@@ -221,12 +221,12 @@
           "value": 550
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 422.5
+          "value": 422.5,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 200
+          "value": 200,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -237,8 +237,8 @@
           "value": 1632.81
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1765.2
+          "value": 1765.2,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -294,11 +294,11 @@
         }
       },
       "factors": {
-        "slash": 0.3209454545454546,
+        "slash": 0.4800013052380836,
         "pierce": 0.4721030042918455,
         "blunt": 0.19287469287469286,
         "defense_slash": 0.43333333333333335,
-        "defense_pierce": 0.3209454545454546,
+        "defense_pierce": 0.4800013052380836,
         "defense_blunt": 0.19287469287469286,
         "fire": 0,
         "water": 0.8071253071253072,
@@ -323,12 +323,12 @@
           "value": 925
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 750
+          "value": 750,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 205
+          "value": 205,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -339,8 +339,8 @@
           "value": 2696.83
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 2843.93
+          "value": 2843.93,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -396,11 +396,11 @@
         }
       },
       "factors": {
-        "slash": 0.5170781818181818,
+        "slash": 0.7733345298015766,
         "pierce": 0.7939914163090128,
         "blunt": 0.19287469287469286,
         "defense_slash": 0.7692307692307693,
-        "defense_pierce": 0.5170781818181818,
+        "defense_pierce": 0.7733345298015766,
         "defense_blunt": 0.19287469287469286,
         "fire": 0,
         "water": 0.8071253071253072,
@@ -425,12 +425,12 @@
           "value": 230
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 85
+          "value": 85,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 119
+          "value": 119,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -441,8 +441,8 @@
           "value": 514.85
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 588.4
+          "value": 588.4,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -498,11 +498,11 @@
         }
       },
       "factors": {
-        "slash": 0.10698181818181816,
+        "slash": 0.1600004350793612,
         "pierce": 0.19742489270386265,
         "blunt": 0.21965601965601964,
         "defense_slash": 0.08717948717948718,
-        "defense_pierce": 0.10698181818181816,
+        "defense_pierce": 0.1600004350793612,
         "defense_blunt": 0.21965601965601964,
         "fire": 0,
         "water": 0.7803439803439803,
@@ -527,12 +527,12 @@
           "value": 425
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 300
+          "value": 300,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 97.5
+          "value": 97.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -543,8 +543,8 @@
           "value": 882.6
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 980.66
+          "value": 980.66,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -600,11 +600,11 @@
         }
       },
       "factors": {
-        "slash": 0.17830181818181817,
+        "slash": 0.2666655789682637,
         "pierce": 0.3648068669527897,
         "blunt": 0.20810810810810812,
         "defense_slash": 0.3076923076923077,
-        "defense_pierce": 0.17830181818181817,
+        "defense_pierce": 0.2666655789682637,
         "defense_blunt": 0.20810810810810812,
         "fire": 0,
         "water": 0.7918918918918919,
@@ -629,12 +629,12 @@
           "value": 500
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 260
+          "value": 260,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 117.5
+          "value": 117.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -645,8 +645,8 @@
           "value": 1225.83
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1372.93
+          "value": 1372.93,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -702,11 +702,11 @@
         }
       },
       "factors": {
-        "slash": 0.24962363636363635,
+        "slash": 0.37333344210317365,
         "pierce": 0.4291845493562232,
         "blunt": 0.21621621621621623,
         "defense_slash": 0.26666666666666666,
-        "defense_pierce": 0.24962363636363635,
+        "defense_pierce": 0.37333344210317365,
         "defense_blunt": 0.21621621621621623,
         "fire": 0,
         "water": 0.7837837837837838,
@@ -731,12 +731,12 @@
           "value": 930
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 467
+          "value": 467,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 209.5
+          "value": 209.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -747,8 +747,8 @@
           "value": 2010.36
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 2181.98
+          "value": 2181.98,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -804,11 +804,11 @@
         }
       },
       "factors": {
-        "slash": 0.39672363636363633,
+        "slash": 0.5933340403372953,
         "pierce": 0.7982832618025751,
         "blunt": 0.20737100737100733,
         "defense_slash": 0.47897435897435897,
-        "defense_pierce": 0.39672363636363633,
+        "defense_pierce": 0.5933340403372953,
         "defense_blunt": 0.20737100737100733,
         "fire": 0,
         "water": 0.7926289926289927,
@@ -833,12 +833,12 @@
           "value": 1080
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 790
+          "value": 790,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 209.5
+          "value": 209.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -849,8 +849,8 @@
           "value": 2353.6
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 2794.9
+          "value": 2794.9,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -906,11 +906,11 @@
         }
       },
       "factors": {
-        "slash": 0.5081636363636364,
+        "slash": 0.7600020666269658,
         "pierce": 0.927038626609442,
         "blunt": 0.2012285012285012,
         "defense_slash": 0.8102564102564103,
-        "defense_pierce": 0.5081636363636364,
+        "defense_pierce": 0.7600020666269658,
         "defense_blunt": 0.2012285012285012,
         "fire": 0,
         "water": 0.7987714987714988,
@@ -935,12 +935,12 @@
           "value": 550
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 190
+          "value": 190,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 185
+          "value": 185,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -951,8 +951,8 @@
           "value": 1323.9
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1716.16
+          "value": 1716.16,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1008,11 +1008,11 @@
         }
       },
       "factors": {
-        "slash": 0.3120290909090909,
+        "slash": 0.4666661228174652,
         "pierce": 0.4721030042918455,
         "blunt": 0.21621621621621623,
         "defense_slash": 0.19487179487179487,
-        "defense_pierce": 0.3120290909090909,
+        "defense_pierce": 0.4666661228174652,
         "defense_blunt": 0.21621621621621623,
         "fire": 0,
         "water": 0.7837837837837838,
@@ -1037,12 +1037,12 @@
           "value": 740
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 327.5
+          "value": 327.5,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 207.5
+          "value": 207.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1053,8 +1053,8 @@
           "value": 2059.4
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 2206.5
+          "value": 2206.5,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1110,11 +1110,11 @@
         }
       },
       "factors": {
-        "slash": 0.4011818181818182,
+        "slash": 0.6000016315476046,
         "pierce": 0.6351931330472103,
         "blunt": 0.21842751842751842,
         "defense_slash": 0.33589743589743587,
-        "defense_pierce": 0.4011818181818182,
+        "defense_pierce": 0.6000016315476046,
         "defense_blunt": 0.21842751842751842,
         "fire": 0,
         "water": 0.7815724815724816,
@@ -1139,12 +1139,12 @@
           "value": 265
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 160
+          "value": 160,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 45
+          "value": 45,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1155,8 +1155,8 @@
           "value": 514.85
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 612.92
+          "value": 612.92,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1212,11 +1212,11 @@
         }
       },
       "factors": {
-        "slash": 0.11143999999999998,
+        "slash": 0.1666680262896704,
         "pierce": 0.22746781115879827,
         "blunt": 0.04373464373464373,
         "defense_slash": 0.1641025641025641,
-        "defense_pierce": 0.11143999999999998,
+        "defense_pierce": 0.1666680262896704,
         "defense_blunt": 0.04373464373464373,
         "fire": 0,
         "water": 0.9562653562653562,
@@ -1241,12 +1241,12 @@
           "value": 632.5
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 245
+          "value": 245,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 193
+          "value": 193,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1257,8 +1257,8 @@
           "value": 1716.16
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1814.23
+          "value": 1814.23,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1314,11 +1314,11 @@
         }
       },
       "factors": {
-        "slash": 0.32986,
+        "slash": 0.49333376841269455,
         "pierce": 0.5429184549356223,
         "blunt": 0.19484029484029483,
         "defense_slash": 0.2512820512820513,
-        "defense_pierce": 0.32986,
+        "defense_pierce": 0.49333376841269455,
         "defense_blunt": 0.19484029484029483,
         "fire": 0,
         "water": 0.8051597051597051,
@@ -1343,12 +1343,12 @@
           "value": 495
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 367.5
+          "value": 367.5,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 73
+          "value": 73,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1359,8 +1359,8 @@
           "value": 1274.86
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1397.45
+          "value": 1397.45,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1416,11 +1416,11 @@
         }
       },
       "factors": {
-        "slash": 0.2540818181818182,
+        "slash": 0.3800010333134829,
         "pierce": 0.4248927038626609,
         "blunt": 0.06830466830466829,
         "defense_slash": 0.3769230769230769,
-        "defense_pierce": 0.2540818181818182,
+        "defense_pierce": 0.3800010333134829,
         "defense_blunt": 0.06830466830466829,
         "fire": 0,
         "water": 0.9316953316953317,
@@ -1445,12 +1445,12 @@
           "value": 1165
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 975
+          "value": 975,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 200
+          "value": 200,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1461,8 +1461,8 @@
           "value": 3481.36
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 3677.49
+          "value": 3677.49,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1518,11 +1518,11 @@
         }
       },
       "factors": {
-        "slash": 0.6686345454545454,
+        "slash": 1,
         "pierce": 1,
         "blunt": 0.1904176904176904,
         "defense_slash": 1,
-        "defense_pierce": 0.6686345454545454,
+        "defense_pierce": 1,
         "defense_blunt": 0.1904176904176904,
         "fire": 0,
         "water": 0.8095823095823096,
@@ -1547,12 +1547,12 @@
           "value": 345
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 185
+          "value": 185,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 105
+          "value": 105,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1563,8 +1563,8 @@
           "value": 858.08
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 956.15
+          "value": 956.15,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1620,11 +1620,11 @@
         }
       },
       "factors": {
-        "slash": 0.17384545454545453,
+        "slash": 0.26000070700396194,
         "pierce": 0.296137339055794,
         "blunt": 0.21867321867321868,
         "defense_slash": 0.18974358974358974,
-        "defense_pierce": 0.17384545454545453,
+        "defense_pierce": 0.26000070700396194,
         "defense_blunt": 0.21867321867321868,
         "fire": 0,
         "water": 0.7813267813267813,
@@ -1649,12 +1649,12 @@
           "value": 280
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 155
+          "value": 155,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 70.5
+          "value": 70.5,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1665,8 +1665,8 @@
           "value": 735.5
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 858.08
+          "value": 858.08,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1722,11 +1722,11 @@
         }
       },
       "factors": {
-        "slash": 0.15601454545454546,
+        "slash": 0.2333330614087326,
         "pierce": 0.24034334763948498,
         "blunt": 0.06535626535626536,
         "defense_slash": 0.15897435897435896,
-        "defense_pierce": 0.15601454545454546,
+        "defense_pierce": 0.2333330614087326,
         "defense_blunt": 0.06535626535626536,
         "fire": 0,
         "water": 0.9346437346437346,
@@ -1751,12 +1751,12 @@
           "value": 515
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 377.5
+          "value": 377.5,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 73
+          "value": 73,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1767,8 +1767,8 @@
           "value": 1323.9
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 1421.96
+          "value": 1421.96,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1824,11 +1824,11 @@
         }
       },
       "factors": {
-        "slash": 0.25853818181818183,
+        "slash": 0.3866659052777846,
         "pierce": 0.44206008583690987,
         "blunt": 0.06977886977886977,
         "defense_slash": 0.3871794871794872,
-        "defense_pierce": 0.25853818181818183,
+        "defense_pierce": 0.3866659052777846,
         "defense_blunt": 0.06977886977886977,
         "fire": 0,
         "water": 0.9302211302211303,
@@ -1853,12 +1853,12 @@
           "value": 165
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 75
+          "value": 75,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 70
+          "value": 70,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1869,8 +1869,8 @@
           "value": 416.78
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 490.33
+          "value": 490.33,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -1926,11 +1926,11 @@
         }
       },
       "factors": {
-        "slash": 0.08915090909090909,
+        "slash": 0.13333278948413185,
         "pierce": 0.14163090128755365,
         "blunt": 0.06707616707616706,
         "defense_slash": 0.07692307692307693,
-        "defense_pierce": 0.08915090909090909,
+        "defense_pierce": 0.13333278948413185,
         "defense_blunt": 0.06707616707616706,
         "fire": 0,
         "water": 0.932923832923833,
@@ -1955,12 +1955,12 @@
           "value": 975
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": 725
+          "value": 725,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": 245
+          "value": 245,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -1971,8 +1971,8 @@
           "value": 3285.23
         },
         "vickers_hardness": {
-          "units": "MPa",
-          "value": 3481.36
+          "value": 3481.36,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2028,11 +2028,11 @@
         }
       },
       "factors": {
-        "slash": 0.6329745454545455,
+        "slash": 0.9466674280555488,
         "pierce": 0.8369098712446352,
         "blunt": 0.20393120393120392,
         "defense_slash": 0.7435897435897436,
-        "defense_pierce": 0.6329745454545455,
+        "defense_pierce": 0.9466674280555488,
         "defense_blunt": 0.20393120393120392,
         "fire": 0,
         "water": 0.7960687960687961,
@@ -2057,12 +2057,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2073,8 +2073,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2147,12 +2147,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2163,8 +2163,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2237,12 +2237,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2253,8 +2253,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2327,12 +2327,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2343,8 +2343,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2417,12 +2417,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2433,8 +2433,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2507,12 +2507,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2523,8 +2523,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2597,12 +2597,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2613,8 +2613,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2687,12 +2687,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2703,8 +2703,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2777,12 +2777,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2793,8 +2793,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2867,12 +2867,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2883,8 +2883,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -2957,12 +2957,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -2973,8 +2973,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3047,12 +3047,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3063,8 +3063,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3137,12 +3137,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3153,8 +3153,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3227,12 +3227,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3243,8 +3243,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3317,12 +3317,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3333,8 +3333,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3407,12 +3407,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3423,8 +3423,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3497,12 +3497,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3513,8 +3513,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3587,12 +3587,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3603,8 +3603,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3677,12 +3677,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3693,8 +3693,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3767,12 +3767,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3783,8 +3783,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3857,12 +3857,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3873,8 +3873,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -3947,12 +3947,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -3963,8 +3963,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4037,12 +4037,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4053,8 +4053,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4127,12 +4127,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4143,8 +4143,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4217,12 +4217,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4233,8 +4233,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4307,12 +4307,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4323,8 +4323,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4397,12 +4397,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4413,8 +4413,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4487,12 +4487,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4503,8 +4503,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4577,12 +4577,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4593,8 +4593,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4667,12 +4667,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4683,8 +4683,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4757,12 +4757,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4773,8 +4773,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4847,12 +4847,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4863,8 +4863,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -4937,12 +4937,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -4953,8 +4953,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5027,12 +5027,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5043,8 +5043,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5117,12 +5117,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5133,8 +5133,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5207,12 +5207,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5223,8 +5223,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5297,12 +5297,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5313,8 +5313,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5387,12 +5387,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5403,8 +5403,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5477,12 +5477,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5493,8 +5493,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5567,12 +5567,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5583,8 +5583,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5657,12 +5657,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5673,8 +5673,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5747,12 +5747,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5763,8 +5763,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5837,12 +5837,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5853,8 +5853,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -5927,12 +5927,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -5943,8 +5943,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6017,12 +6017,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6033,8 +6033,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6107,12 +6107,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6123,8 +6123,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6197,12 +6197,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6213,8 +6213,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6287,12 +6287,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6303,8 +6303,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6377,12 +6377,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6393,8 +6393,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6467,12 +6467,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6483,8 +6483,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6557,12 +6557,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6573,8 +6573,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6647,12 +6647,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6663,8 +6663,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6737,12 +6737,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6753,8 +6753,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6827,12 +6827,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6843,8 +6843,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -6917,12 +6917,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -6933,8 +6933,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7007,12 +7007,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7023,8 +7023,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7097,12 +7097,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7113,8 +7113,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7187,12 +7187,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7203,8 +7203,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7277,12 +7277,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7293,8 +7293,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7367,12 +7367,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7383,8 +7383,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7457,12 +7457,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7473,8 +7473,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7547,12 +7547,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7563,8 +7563,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7637,12 +7637,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7653,8 +7653,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7727,12 +7727,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7743,8 +7743,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7817,12 +7817,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7833,8 +7833,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7907,12 +7907,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -7923,8 +7923,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -7997,12 +7997,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8013,8 +8013,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8087,12 +8087,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8103,8 +8103,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8177,12 +8177,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8193,8 +8193,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8267,12 +8267,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8283,8 +8283,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8357,12 +8357,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8373,8 +8373,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8447,12 +8447,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8463,8 +8463,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8537,12 +8537,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8553,8 +8553,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8627,12 +8627,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8643,8 +8643,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",
@@ -8717,12 +8717,12 @@
           "value": "N/A"
         },
         "yield_strength": {
-          "units": "MPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "youngs_modulus": {
-          "units": "GPa",
-          "value": "N/A"
+          "value": 0,
+          "units": "GPa"
         },
         "mohs_hardness": {
           "units": "Mohs",
@@ -8733,8 +8733,8 @@
           "value": "N/A"
         },
         "vickers_hardness": {
-          "units": "HV",
-          "value": "N/A"
+          "value": 0,
+          "units": "MPa"
         },
         "density": {
           "units": "g/cm3",

--- a/public/crafting_calculator.js
+++ b/public/crafting_calculator.js
@@ -111,19 +111,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 woodList,
                 elementalList,
                 alloyList,
-                armorVolumesList,
-                shieldVolumesList,
-                weaponVolumesList,
-                potionHerbs,
-                runesList,
-                bannedNamesText,
                 rockTypes,
                 armorVolumesList,
                 shieldVolumesList,
                 weaponVolumesList,
                 potionIngredientsList,
                 enchantmentRunesList,
-                bannedNamesList,
+                bannedNamesText,
                 alchemyRecipesList
             ] = await Promise.all([
                 getDatabaseSection('materials'),
@@ -185,12 +179,12 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             console.log("Weapon volumes processed.");
 
-            potionIngredientsData = potionHerbs.map(h => ({
+            potionIngredientsData = potionIngredientsList.map(h => ({
                 RowName: h.name.replace(/\s+/g, '_'),
                 Name: h.name,
                 factors: h.factors,
             }));
-            enchantmentRunesData = runesList;
+            enchantmentRunesData = enchantmentRunesList;
             alchemyRecipesData = alchemyRecipesList;
             console.log("Ingredients, runes, and recipes assigned.");
 

--- a/public/database.json
+++ b/public/database.json
@@ -4,6 +4,7 @@
   "rockTypes": "rock_types.json",
   "elementalMetals": "Master_Elemental_Metals.json",
   "metalAlloys": "Master_Metal_Alloys.json",
+  "mechanicalLimits": "mechanical_limits.json",
   "armorVolumes": "armor_volumes.json",
   "shieldVolumes": "shield_volumes.json",
   "weaponVolumes": "weapon_volumes.json",

--- a/public/mechanical_limits.json
+++ b/public/mechanical_limits.json
@@ -1,0 +1,14 @@
+{
+  "hardness": {
+    "max": 3677.49,
+    "units": "MPa"
+  },
+  "elasticModulus": {
+    "max": 287,
+    "units": "GPa"
+  },
+  "yieldStrength": {
+    "max": 975,
+    "units": "MPa"
+  }
+}

--- a/scripts/populateMetalFactors.js
+++ b/scripts/populateMetalFactors.js
@@ -14,36 +14,51 @@ function num(val){
   return Number(val);
 }
 
-function hardness(mp){
-  if(!mp) return 0;
-  const mh = num(mp.mohs_hardness?.value);
-  if(mh) return mh;
-  const vh = num(mp.vickers_hardness?.value);
-  if(vh) return vh/1000;
-  const bh = num(mp.brinell_hardness?.value);
-  if(bh) return bh/1000;
-  return 0;
+function ensureMechanicalProps(mp){
+  // Standardize hardness to MPa using vickers, brinell or mohs values
+  let hv = num(mp.vickers_hardness?.value);
+  if(!hv){
+    const bh = num(mp.brinell_hardness?.value);
+    if(bh) hv = bh; else {
+      const mh = num(mp.mohs_hardness?.value);
+      hv = mh ? mh * 1000 : 0;
+    }
+  }
+  mp.vickers_hardness = { value: hv, units: 'MPa' };
+
+  const ys = num(mp.yield_strength?.value);
+  mp.yield_strength = { value: ys, units: 'MPa' };
+
+  const ym = num(mp.youngs_modulus?.value);
+  mp.youngs_modulus = { value: ym, units: 'GPa' };
+
+  return mp;
 }
 
 const datasets = files.map(readJSON);
 const elements = datasets.flatMap(d => d.elements);
 
+for(const el of elements){
+  el.mechanical_properties = ensureMechanicalProps(el.mechanical_properties || {});
+}
+
 function gatherMax(fn){
   return elements.reduce((m,el)=>Math.max(m,fn(el)),0);
 }
 
-const maxHard = gatherMax(el=>hardness(el.mechanical_properties));
-const maxTensile = gatherMax(el=>num(el.mechanical_properties?.ultimate_tensile_strength?.value));
+const maxHard = gatherMax(el=>num(el.mechanical_properties?.vickers_hardness?.value));
+const maxElastic = gatherMax(el=>num(el.mechanical_properties?.youngs_modulus?.value));
 const maxYield = gatherMax(el=>num(el.mechanical_properties?.yield_strength?.value));
+const maxTensile = gatherMax(el=>num(el.mechanical_properties?.ultimate_tensile_strength?.value));
 const maxDensity = gatherMax(el=>num(el.mechanical_properties?.density?.value ?? el.density));
 const maxMelt = gatherMax(el=>num(el.melt));
 const maxEA = gatherMax(el=>num(el.electron_affinity));
 
 for(const el of elements){
-  const mp = el.mechanical_properties || {};
-  const hard = hardness(mp);
+  const mp = el.mechanical_properties;
+  const hard = num(mp.vickers_hardness.value);
   const tensile = num(mp.ultimate_tensile_strength?.value);
-  const yieldStrength = num(mp.yield_strength?.value);
+  const yieldStrength = num(mp.yield_strength.value);
   const dens = num(mp.density?.value ?? el.density);
   const melt = num(el.melt);
   const ea = num(el.electron_affinity);
@@ -61,6 +76,14 @@ for(const el of elements){
     earth: maxDensity ? dens / maxDensity : 0
   };
 }
+
+const limits = {
+  hardness: { max: maxHard, units: 'MPa' },
+  elasticModulus: { max: maxElastic, units: 'GPa' },
+  yieldStrength: { max: maxYield, units: 'MPa' }
+};
+
+fs.writeFileSync('public/mechanical_limits.json', JSON.stringify(limits, null, 2) + '\n');
 
 datasets.forEach((data,i)=>{
   fs.writeFileSync(files[i], JSON.stringify(data, null, 2)+"\n");


### PR DESCRIPTION
## Summary
- Correct Promise.all destructuring in crafting_calculator to load armor volume data and related lists
- Ensure potion ingredient and rune data populate correctly
- Normalize mechanical property fields across metals and expose maximum hardness, elastic modulus, and yield strength values via shared database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acb60d6dec8330afd770e43f6c1cdd