### PR TITLE
feat: separate attack controls from weapon panel

### DIFF
--- a/src/components/AttackDirectionPanel.jsx
+++ b/src/components/AttackDirectionPanel.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+const DIRECTIONS = ["Left","Right","Up","Down"];
+
+export default function AttackDirectionPanel({ weapon, direction, setDirection, charge, setCharge, swing, setSwing }) {
+  if (!weapon) return null;
+  return (
+    <section className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg">
+      <h2 className="text-lg font-semibold mb-3">Attack</h2>
+      <div className="grid grid-cols-1 gap-3">
+        {weapon.type === 'melee' && (
+          <div>
+            <label className="block text-sm mb-1">Attack Direction</label>
+            <div className="grid grid-cols-1 gap-2">
+              {DIRECTIONS.map(d => (
+                <button
+                  key={d}
+                  onClick={() => setDirection(d)}
+                  className={`w-full px-3 py-2 text-sm rounded-lg border ${direction === d ? "border-emerald-400 bg-emerald-400/10" : "border-slate-700"}`}
+                >
+                  {d}
+                </button>
+              ))}
+            </div>
+            <div className="text-sm text-slate-300 mt-1">
+              Each direction selects a different type of damage for your weapon. For example, the downward direction with a sword is a piercing thrust.
+            </div>
+          </div>
+        )}
+
+        {weapon.type !== 'mounted' && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <div className="flex items-center justify-between text-sm">
+                <span>Charge Time</span>
+                <span className="tabular-nums">{charge.toFixed(2)} seconds</span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={1.5}
+                step={0.01}
+                value={charge}
+                onChange={e => setCharge(parseFloat(e.target.value))}
+                className="w-full"
+              />
+              <div className="text-sm text-slate-300 mt-1">
+                If your charge time is one and a half seconds, the attack is a heavy attack and costs twice as much stamina.
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between text-sm">
+                <span>Swing Completion</span>
+                <span className="tabular-nums">{(swing * 100).toFixed(0)}%</span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={swing}
+                onChange={e => setSwing(parseFloat(e.target.value))}
+                className="w-full"
+              />
+              <div className="text-sm text-slate-300 mt-1">
+                If your swing completion is below sixty percent, your attack does no damage. Otherwise damage scales with completion.
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/WeaponAttackPanel.jsx
+++ b/src/components/WeaponAttackPanel.jsx
@@ -10,9 +10,8 @@ const BOW_TYPES = {
   Flat:    { drawWeight: 40, massKilograms: 0.9 },
 };
 
-const DIRECTIONS = ["Left","Right","Up","Down"];
 
-export default function WeaponAttackPanel({ weaponKey, setWeaponKey, weapon, bowType, setBowType, bowWood, setBowWood, weaponComps, setWeaponComp, isTwoHanded, setTwoHanded, direction, setDirection, charge, setCharge, swing, setSwing, mountedSpeed, setMountedSpeed, armor, DB, subcategoriesFor, itemsForCategory, firstSubCat, firstMat }) {
+export default function WeaponAttackPanel({ weaponKey, setWeaponKey, weapon, bowType, setBowType, bowWood, setBowWood, weaponComps, setWeaponComp, isTwoHanded, setTwoHanded, mountedSpeed, setMountedSpeed, armor, DB, subcategoriesFor, itemsForCategory, firstSubCat, firstMat }) {
   return (
     <section className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg">
       <h2 className="text-lg font-semibold mb-3">Melee</h2>
@@ -85,20 +84,6 @@ export default function WeaponAttackPanel({ weaponKey, setWeaponKey, weapon, bow
             </div>
           </div>
         )}
-        {weapon?.type==='melee' && (
-          <div>
-            <label className="block text-sm mb-1">Attack Direction</label>
-            <div className="grid grid-cols-1 gap-2">
-              {DIRECTIONS.map(d=> (
-                <button key={d} onClick={() => setDirection(d)} className={`w-full px-3 py-2 text-sm rounded-lg border ${direction===d ? "border-emerald-400 bg-emerald-400/10" : "border-slate-700"}`}>
-                  {d}
-                </button>
-              ))}
-            </div>
-            <div className="text-sm text-slate-300 mt-1">Each direction selects a different type of damage for your weapon. For example, the downward direction with a sword is a piercing thrust.</div>
-          </div>
-        )}
-
         {weapon?.type==='mounted' && (
           <div>
             <label className="block text-sm mb-1">Mount Speed</label>
@@ -106,27 +91,6 @@ export default function WeaponAttackPanel({ weaponKey, setWeaponKey, weapon, bow
               {Object.keys(WEAPONS.Lance.speed).map(k=> <option key={k} value={k}>{k}</option>)}
             </select>
             <div className="text-sm text-slate-300 mt-1">Lance attacks do not use charge time or swing completion. Damage scales with the speed of the mount.</div>
-          </div>
-        )}
-
-        {weapon && weapon.type!=='mounted' && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <div className="flex items-center justify-between text-sm">
-                <span>Charge Time</span>
-                <span className="tabular-nums">{charge.toFixed(2)} seconds</span>
-              </div>
-              <input type="range" min={0} max={1.5} step={0.01} value={charge} onChange={e=>setCharge(parseFloat(e.target.value))} className="w-full" />
-              <div className="text-sm text-slate-300 mt-1">If your charge time is one and a half seconds, the attack is a heavy attack and costs twice as much stamina.</div>
-            </div>
-            <div>
-              <div className="flex items-center justify-between text-sm">
-                <span>Swing Completion</span>
-                <span className="tabular-nums">{(swing*100).toFixed(0)}%</span>
-              </div>
-              <input type="range" min={0} max={1} step={0.01} value={swing} onChange={e=>setSwing(parseFloat(e.target.value))} className="w-full" />
-              <div className="text-sm text-slate-300 mt-1">If your swing completion is below sixty percent, your attack does no damage. Otherwise damage scales with completion.</div>
-            </div>
           </div>
         )}
       </div>

--- a/src/simulator.jsx
+++ b/src/simulator.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import { WEAPONS, MATERIALS_FOR_HANDLE_CORE, MATERIALS_FOR_HANDLE_GRIP, MATERIALS_FOR_HANDLE_FITTING, MATERIALS_FOR_HEAD, BANNED_WEAPON_HEAD_MATERIALS } from "./constants/weapons.js";
 import CharacterPanel from "./components/CharacterPanel.jsx";
+import AttackDirectionPanel from "./components/AttackDirectionPanel.jsx";
 import WeaponAttackPanel from "./components/WeaponAttackPanel.jsx";
 import RangedWeaponPanel from "./components/RangedWeaponPanel.jsx";
 import MaterialSelect from "./components/MaterialSelect.jsx";
@@ -490,10 +491,10 @@ function App({ DB }){
       statsWithJewelry.PSY = Math.min(100, statsWithJewelry.PSY);
 
       const eff = {
-        STR: Math.min(100, Math.max(0, statsWithJewelry.STR + (race.modifier.STR||0))),
-        DEX: Math.min(100, Math.max(0, statsWithJewelry.DEX + (race.modifier.DEX||0))),
-        INT: Math.min(100, Math.max(0, statsWithJewelry.INT + (race.modifier.INT||0))),
-        PSY: Math.min(100, Math.max(0, statsWithJewelry.PSY + (race.modifier.PSY||0))),
+        STR: Math.max(0, statsWithJewelry.STR + (race.modifier.STR || 0)),
+        DEX: Math.max(0, statsWithJewelry.DEX + (race.modifier.DEX || 0)),
+        INT: Math.max(0, statsWithJewelry.INT + (race.modifier.INT || 0)),
+        PSY: Math.max(0, statsWithJewelry.PSY + (race.modifier.PSY || 0)),
       };
       return { effective: eff, jewelryBonus: bonus };
   }, [stats, race, armor]);
@@ -678,6 +679,15 @@ function App({ DB }){
                 STAT_POOL={STAT_POOL}
                 HEALTH_FIXED={HEALTH_FIXED}
               />
+              <AttackDirectionPanel
+                weapon={weapon}
+                direction={direction}
+                setDirection={setDirection}
+                charge={charge}
+                setCharge={setCharge}
+                swing={swing}
+                setSwing={setSwing}
+              />
             </div>
 
             {/* Center column: Skills */}
@@ -789,12 +799,6 @@ function App({ DB }){
                 setWeaponComp={setWeaponComp}
                 isTwoHanded={isTwoHanded}
                 setTwoHanded={setTwoHanded}
-                direction={direction}
-                setDirection={setDirection}
-                charge={charge}
-                setCharge={setCharge}
-                swing={swing}
-                setSwing={setSwing}
                 mountedSpeed={mountedSpeed}
                 setMountedSpeed={setMountedSpeed}
                 armor={armor}


### PR DESCRIPTION
## Summary
- extract attack direction, charge, and swing inputs into new AttackDirectionPanel
- position AttackDirectionPanel beneath the Character panel
- simplify WeaponAttackPanel to focus on weapon and mount speed options
- apply racial bonuses after player attribute investments so bonuses can raise or lower final stats

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acf867d06c8330a3cc157224dc1d2c