### PR TITLE
Clone DB for damage factor normalization and add immutability test

### DIFF
--- a/src/hooks/useMaterials.js
+++ b/src/hooks/useMaterials.js
@@ -53,8 +53,8 @@ export default function useMaterials() {
             },
           },
         ];
-        normalizeDamageFactorsByCategory(built);
-        if (!cancelled) setDb(built);
+        const normalized = normalizeDamageFactorsByCategory(built);
+        if (!cancelled) setDb(normalized);
       } catch (e) {
         if (!cancelled) setError(e);
       }

--- a/src/materialCalculations.js
+++ b/src/materialCalculations.js
@@ -322,6 +322,8 @@ function feelTransform(r) {
 // material category (e.g., Metals vs. Wood) is scaled independently. This
 // prevents cross-category comparisons such as bone vs. steel.
 export function normalizeDamageFactorsByCategory(db) {
+  // Work on a deep clone so the original database remains untouched.
+  const out = structuredClone(db);
   const maxes = {};
 
   const gather = (node, top) => {
@@ -356,10 +358,10 @@ export function normalizeDamageFactorsByCategory(db) {
     }
   };
 
-  gather(db, null);
-  apply(db, null);
+  gather(out, null);
+  apply(out, null);
 
-  return db;
+  return out;
 }
 
 export default calculateMaterialDefenses;

--- a/tests/materialCalculations.test.js
+++ b/tests/materialCalculations.test.js
@@ -68,14 +68,35 @@ describe('calculateMaterialDefenses', () => {
         ]
       }
     };
-    normalizeDamageFactorsByCategory(db);
-    const metals = db.Metals.Stuff;
+    const normalized = normalizeDamageFactorsByCategory(db);
+    const metals = normalized.Metals.Stuff;
     expect(Math.max(...metals.map(m=>m.factors.slash))).toBeCloseTo(1);
     expect(Math.max(...metals.map(m=>m.factors.pierce))).toBeCloseTo(1);
     expect(Math.max(...metals.map(m=>m.factors.blunt))).toBeCloseTo(1);
-    const woods = db.Wood.Any;
+    const woods = normalized.Wood.Any;
     expect(Math.max(...woods.map(m=>m.factors.slash))).toBeCloseTo(1);
     expect(Math.max(...woods.map(m=>m.factors.pierce))).toBeCloseTo(1);
     expect(Math.max(...woods.map(m=>m.factors.blunt))).toBeCloseTo(1);
+  });
+
+  it('does not mutate the original database object', () => {
+    const db = {
+      Metals: {
+        Stuff: [
+          { name: 'Iron', factors: { slash: 10, pierce: 5, blunt: 2 } },
+          { name: 'Steel', factors: { slash: 20, pierce: 10, blunt: 4 } }
+        ]
+      },
+      Wood: {
+        Any: [
+          { name: 'Oak', factors: { slash: 3, pierce: 1, blunt: 1 } },
+          { name: 'Pine', factors: { slash: 6, pierce: 2, blunt: 2 } }
+        ]
+      }
+    };
+    const original = structuredClone(db);
+    const normalized = normalizeDamageFactorsByCategory(db);
+    expect(db).toEqual(original);
+    expect(normalized).not.toBe(db);
   });
 });


### PR DESCRIPTION
## Summary
- avoid mutating database in `normalizeDamageFactorsByCategory` by deep cloning input
- update materials hook and tests to use returned normalized copy
- add test ensuring original DB remains unchanged after normalization

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad16c5cc748330a9083d65dc26d2a5