### PR TITLE
refactor: centralize bow type constants

### DIFF
--- a/src/components/WeaponAttackPanel.jsx
+++ b/src/components/WeaponAttackPanel.jsx
@@ -1,14 +1,6 @@
 import React from "react";
 import MaterialSelect from "./MaterialSelect.jsx";
-import { WEAPONS, MATERIALS_FOR_HANDLE_CORE, MATERIALS_FOR_HANDLE_GRIP, MATERIALS_FOR_HANDLE_FITTING, MATERIALS_FOR_HEAD, BANNED_WEAPON_HEAD_MATERIALS } from "../constants/weapons.js";
-
-const BOW_TYPES = {
-  Long:    { drawWeight: 60, massKilograms: 1.2 },
-  Recurve: { drawWeight: 50, massKilograms: 1.0 },
-  Yumi:    { drawWeight: 55, massKilograms: 1.1 },
-  Horse:   { drawWeight: 45, massKilograms: 0.8 },
-  Flat:    { drawWeight: 40, massKilograms: 0.9 },
-};
+import { WEAPONS, MATERIALS_FOR_HANDLE_CORE, MATERIALS_FOR_HANDLE_GRIP, MATERIALS_FOR_HANDLE_FITTING, MATERIALS_FOR_HEAD, BANNED_WEAPON_HEAD_MATERIALS, BOW_TYPES } from "../constants/weapons.js";
 
 
 export default function WeaponAttackPanel({ weaponKey, setWeaponKey, weapon, bowType, setBowType, bowWood, setBowWood, weaponComps, setWeaponComp, isTwoHanded, setTwoHanded, mountedSpeed, setMountedSpeed, armor, DB, subcategoriesFor, itemsForCategory, firstSubCat, firstMat }) {

--- a/src/constants/weapons.js
+++ b/src/constants/weapons.js
@@ -18,3 +18,11 @@ export const MATERIALS_FOR_HANDLE_GRIP = ["Linen", "Leather", "Dev"];
 export const MATERIALS_FOR_HANDLE_FITTING = ["Metals", "Rock Types", "Dev"];
 export const MATERIALS_FOR_HEAD = ["Metals", "Rock Types", "Wood", "Dev"];
 export const BANNED_WEAPON_HEAD_MATERIALS = ["Carapace", "Fur", "Herbs", "Leather", "Linen", "Scales"];
+
+export const BOW_TYPES = {
+  Long:    { drawWeight: 60, massKilograms: 1.2 },
+  Recurve: { drawWeight: 50, massKilograms: 1.0 },
+  Yumi:    { drawWeight: 55, massKilograms: 1.1 },
+  Horse:   { drawWeight: 45, massKilograms: 0.8 },
+  Flat:    { drawWeight: 40, massKilograms: 0.9 },
+};

--- a/src/simulator.jsx
+++ b/src/simulator.jsx
@@ -7,6 +7,7 @@ import {
   MATERIALS_FOR_HANDLE_FITTING,
   MATERIALS_FOR_HEAD,
   BANNED_WEAPON_HEAD_MATERIALS,
+  BOW_TYPES,
 } from "./constants/weapons.js";
 import {
   armorSlots,
@@ -45,16 +46,6 @@ const races = [
   { id: "goliath", name: "Goliath", modifier: { STR: 8, DEX: -4, INT: -8, PSY: 0 }, magicProficiency: "Void" },
   { id: "fae",   name: "Fae",    modifier: { STR: -8, DEX: 0, INT: 8, PSY: -4 }, magicProficiency: "Radiance" },
 ];
-
-
-// Weapons
-const BOW_TYPES = {
-  Long:    { drawWeight: 60, massKilograms: 1.2 },
-  Recurve: { drawWeight: 50, massKilograms: 1.0 },
-  Yumi:    { drawWeight: 55, massKilograms: 1.1 },
-  Horse:   { drawWeight: 45, massKilograms: 0.8 },
-  Flat:    { drawWeight: 40, massKilograms: 0.9 },
-};
 
 const DIRECTIONS = ["Left","Right","Up","Down"];
 


### PR DESCRIPTION
## Summary
- centralize `BOW_TYPES` definition in shared weapons constants
- import shared bow types in simulator and weapon attack panel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1eb3cca083308fec0d9265d3d2bb