### PR TITLE
Enable shield boss selection for elemental and alloy metals

### DIFF
--- a/public/crafting.html
+++ b/public/crafting.html
@@ -199,7 +199,7 @@
                   </div>
                   <div>
                     <label for="shield-boss-category" class="block text-sm font-medium text-slate-300">Boss Category</label>
-                    <select id="shield-boss-category" name="shield-boss-category" disabled class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
+                    <select id="shield-boss-category" name="shield-boss-category" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md bg-slate-700 text-white"></select>
                   </div>
                   <div>
                     <label for="shield-boss-material" class="block text-sm font-medium text-slate-300">Boss Material</label>

--- a/public/crafting_calculator.js
+++ b/public/crafting_calculator.js
@@ -321,12 +321,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const allMaterials = Array.from(materialsData.values());
         const allCategories = [...new Set(allMaterials.map(m => m.Category))].sort();
-        const metalMaterials = allMaterials.filter(m => ['Elemental Metals', 'Metal Alloys', 'Dev'].includes(m.Category));
 
         addOption(shieldBodyCategorySelect, 'Wood', 'Wood');
-        addOption(shieldBossCategorySelect, 'Metal', 'Metal');
+        ['Elemental Metals', 'Metal Alloys'].forEach(cat => addOption(shieldBossCategorySelect, cat, cat));
         shieldBodyCategorySelect.disabled = true;
-        shieldBossCategorySelect.disabled = true;
         allCategories.forEach(cat => addOption(shieldRimCategorySelect, cat, cat));
 
         const populateByCat = (catSel, matSel) => {
@@ -335,11 +333,12 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         populateByCat(shieldBodyCategorySelect, shieldBodyMaterialSelect);
-        populateSelectWithOptions(shieldBossMaterialSelect, metalMaterials);
+        populateByCat(shieldBossCategorySelect, shieldBossMaterialSelect);
         populateByCat(shieldRimCategorySelect, shieldRimMaterialSelect);
 
         [
             [shieldBodyCategorySelect, shieldBodyMaterialSelect],
+            [shieldBossCategorySelect, shieldBossMaterialSelect],
             [shieldRimCategorySelect, shieldRimMaterialSelect]
         ].forEach(([catSel, matSel]) => {
             catSel.addEventListener('change', () => populateByCat(catSel, matSel));

--- a/public/siege_calculator.js
+++ b/public/siege_calculator.js
@@ -115,9 +115,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function allowedCategories(type, comp) {
-        if (type === 'Ammunition') return ['Metals', 'Rock Types', 'Wood', 'Dev'];
-        if (comp === 'frame' || comp === 'head') return ['Wood', 'Metals', 'Dev'];
-        return Object.keys(materialsDB).sort();
+        let categories;
+        if (type === 'Ammunition') {
+            categories = ['Metals', 'Rock Types', 'Wood', 'Dev'];
+        } else if (comp === 'frame' || comp === 'head') {
+            categories = ['Wood', 'Metals', 'Dev'];
+        } else {
+            categories = Object.keys(materialsDB).sort();
+        }
+
+        if (type === 'Battering Ram') {
+            categories = categories.filter(c => c !== 'Bone');
+        }
+
+        return categories;
     }
 
     function populateSiegeWeaponComponents() {


### PR DESCRIPTION
## Summary
- allow boss category dropdown to choose between Elemental Metals and Metal Alloys
- populate boss materials based on chosen metal category
- remove Bone as a material category when crafting Battering Rams

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad25e12ee48330afff02f37055c291