### PR TITLE
refactor: extract shared navigation partial

### DIFF
--- a/public/ascension.html
+++ b/public/ascension.html
@@ -39,25 +39,7 @@
   <body style="background-image: url('Art/Backgrounds/renewal.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="text-emerald-400 font-semibold">Ascension</a>
-            <a href="magic.html" class="text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">📜 Ascension System</h1>
@@ -162,5 +144,7 @@
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/combat.html
+++ b/public/combat.html
@@ -43,25 +43,7 @@
   <body style="background-image: url('Art/Backgrounds/volcano.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Combat</a>
-            <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">Core & Combat Systems</h1>
@@ -187,5 +169,7 @@
     </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/crafting.html
+++ b/public/crafting.html
@@ -39,28 +39,7 @@
   <body style="background-image: url('Art/Backgrounds/fall.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-7xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="flex items-center gap-2">
-            <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-            <span id="version-display" class="text-sm text-slate-400"></span>
-          </div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Crafting</a>
-            <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">Crafting Professions</h1>
@@ -338,6 +317,7 @@
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
   <script src="version.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -34,28 +34,7 @@
   <body style="background-image: url('Art/Backgrounds/spring.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
       <div class="max-w-7xl mx-auto">
-        <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-          <div class="flex items-center justify-between flex-wrap">
-            <div class="flex items-center gap-2">
-              <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-              <span id="version-display" class="text-sm text-slate-400"></span>
-            </div>
-            <div class="flex flex-wrap gap-4">
-              <a href="index.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Home</a>
-              <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-              <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-              <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-              <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-              <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-              <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-              <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-              <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-              <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-              <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-              <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-            </div>
-          </div>
-        </nav>
+        <div id="nav-container"></div>
 
         <header class="text-center">
           <h1 class="text-4xl font-bold tracking-tight mb-4">Welcome to the Game Simulator</h1>
@@ -95,6 +74,7 @@
         </main>
       </div>
     </div>
+    <script src="nav.js"></script>
     <script src="version.js"></script>
   </body>
 </html>

--- a/public/magic.html
+++ b/public/magic.html
@@ -42,25 +42,7 @@
   <body style="background-image: url('Art/Backgrounds/spring.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Magic</a>
-            <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">Magic System Reference</h1>
@@ -244,5 +226,7 @@
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/materials.html
+++ b/public/materials.html
@@ -34,28 +34,7 @@
   <body style="background-image: url('Art/Backgrounds/renewal.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
       <div class="max-w-7xl mx-auto">
-        <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-          <div class="flex items-center justify-between flex-wrap">
-            <div class="flex items-center gap-2">
-              <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-              <span id="version-display" class="text-sm text-slate-400"></span>
-            </div>
-            <div class="flex flex-wrap gap-4">
-              <a href="index.html" class="text-slate-300 hover:text-emerald-400">Home</a>
-              <a href="materials.html" class="text-emerald-400 font-semibold">Materials</a>
-              <a href="simulator.html" class="text-slate-300 hover:text-emerald-400">Simulator</a>
-              <a href="combat.html" class="text-slate-300 hover:text-emerald-400">Combat</a>
-              <a href="movement.html" class="text-slate-300 hover:text-emerald-400">Movement</a>
-              <a href="races.html" class="text-slate-300 hover:text-emerald-400">Races</a>
-              <a href="ascension.html" class="text-slate-300 hover:text-emerald-400">Ascension</a>
-              <a href="magic.html" class="text-slate-300 hover:text-emerald-400">Magic</a>
-              <a href="spells.html" class="text-slate-300 hover:text-emerald-400">Spells</a>
-              <a href="crafting.html" class="text-slate-300 hover:text-emerald-400">Crafting</a>
-              <a href="siege.html" class="text-slate-300 hover:text-emerald-400">Siege</a>
-              <a href="materials_guide.html" class="text-slate-300 hover:text-emerald-400">Materials Guide</a>
-            </div>
-          </div>
-        </nav>
+        <div id="nav-container"></div>
 
         <header class="text-center">
           <h1 class="text-4xl font-bold tracking-tight mb-4">Material Database</h1>
@@ -233,6 +212,7 @@
 
         loadMaterials();
       </script>
+      <script src="nav.js"></script>
       <script src="version.js"></script>
   </body>
 </html>

--- a/public/materials_guide.html
+++ b/public/materials_guide.html
@@ -34,25 +34,7 @@
 <body style="background-image: url('Art/Backgrounds/winter.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="text-emerald-400 font-semibold">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">A Crafter's Guide to Materials</h1>
@@ -131,8 +113,10 @@
             <p>Furthermore, you can imbue your weapons with elemental magic. This adds a new layer of damage on top of the physical damage, allowing you to exploit your enemy's elemental weaknesses. The material of your weapon head also influences how well it holds an enchantment, making some materials better conduits for magic than others.</p>
         </section>
 
-      </main>
+  </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/movement.html
+++ b/public/movement.html
@@ -39,25 +39,7 @@
   <body style="background-image: url('Art/Backgrounds/fall.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="text-emerald-400 font-semibold">Movement</a>
-            <a href="races.html" class="text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">Movement System</h1>
@@ -166,5 +148,7 @@
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/nav.html
+++ b/public/nav.html
@@ -1,0 +1,22 @@
+<nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
+  <div class="flex items-center justify-between flex-wrap">
+    <div class="flex items-center gap-2">
+      <div class="text-xl font-bold tracking-tight">Game Simulator</div>
+      <span id="version-display" class="text-sm text-slate-400"></span>
+    </div>
+    <div class="flex flex-wrap gap-4">
+      <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
+      <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
+      <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
+      <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
+      <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
+      <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
+      <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
+      <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
+      <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
+      <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
+      <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
+      <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
+    </div>
+  </div>
+</nav>

--- a/public/nav.js
+++ b/public/nav.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const placeholder = document.getElementById('nav-container');
+  if (!placeholder) return;
+  try {
+    const res = await fetch('nav.html');
+    const html = await res.text();
+    placeholder.innerHTML = html;
+    const nav = placeholder.querySelector('nav');
+    if (placeholder.dataset.sticky === 'true' && nav) {
+      nav.classList.add('sticky', 'top-0', 'z-50');
+    }
+    const current = window.location.pathname.split('/').pop();
+    placeholder.querySelectorAll('a[href]').forEach((a) => {
+      const href = a.getAttribute('href');
+      if (href === current) {
+        a.classList.remove('text-slate-300', 'hover:text-emerald-400');
+        a.classList.add('bg-emerald-600', 'text-white', 'rounded');
+      }
+    });
+  } catch (err) {
+    console.error('Failed to load navigation', err);
+  }
+});

--- a/public/races.html
+++ b/public/races.html
@@ -40,25 +40,7 @@
   <body style="background-image: url('Art/Backgrounds/winter.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Races</a>
-            <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-            <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">High Fantasy Sandbox — Race & Lore</h1>
@@ -224,5 +206,7 @@
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/siege.html
+++ b/public/siege.html
@@ -33,25 +33,7 @@
 <body style="background-image: url('Art/Backgrounds/volcano.png'); background-size: cover; background-attachment: fixed;">
   <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
     <div class="max-w-4xl mx-auto">
-      <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-        <div class="flex items-center justify-between flex-wrap">
-          <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-          <div class="flex flex-wrap gap-4">
-            <a href="index.html" class="text-slate-300 hover:text-emerald-400">Home</a>
-            <a href="materials.html" class="text-slate-300 hover:text-emerald-400">Materials</a>
-            <a href="simulator.html" class="text-slate-300 hover:text-emerald-400">Simulator</a>
-            <a href="combat.html" class="text-slate-300 hover:text-emerald-400">Combat</a>
-            <a href="movement.html" class="text-slate-300 hover:text-emerald-400">Movement</a>
-            <a href="races.html" class="text-slate-300 hover:text-emerald-400">Races</a>
-            <a href="ascension.html" class="text-slate-300 hover:text-emerald-400">Ascension</a>
-            <a href="magic.html" class="text-slate-300 hover:text-emerald-400">Magic</a>
-            <a href="spells.html" class="text-slate-300 hover:text-emerald-400">Spells</a>
-            <a href="crafting.html" class="text-slate-300 hover:text-emerald-400">Crafting</a>
-            <a href="siege.html" class="text-emerald-400 font-semibold">Siege</a>
-            <a href="materials_guide.html" class="text-slate-300 hover:text-emerald-400">Materials Guide</a>
-          </div>
-        </div>
-      </nav>
+      <div id="nav-container"></div>
 
       <header class="text-center">
         <h1 class="text-4xl font-bold tracking-tight mb-4">🏰 Siege Engineering</h1>
@@ -78,9 +60,11 @@
               <!-- Results will be populated by JavaScript -->
             </div>
           </div>
-        </section>
+      </section>
       </main>
     </div>
   </div>
+  <script src="nav.js"></script>
+  <script src="version.js"></script>
 </body>
 </html>

--- a/public/simulator.html
+++ b/public/simulator.html
@@ -36,31 +36,14 @@
   <body style="background-image: url('Art/Backgrounds/summer.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/70 text-slate-100 p-4 md:p-8">
       <div class="max-w-7xl mx-auto">
-        <nav class="sticky top-0 z-50 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-          <div class="flex items-center justify-between flex-wrap">
-            <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-            <div class="flex flex-wrap gap-4">
-              <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-              <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-              <a href="simulator.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Simulator</a>
-              <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-              <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-              <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-              <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-              <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-              <a href="spells.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Spells</a>
-              <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-              <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-              <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-            </div>
-          </div>
-        </nav>
+        <div id="nav-container" data-sticky="true"></div>
         <div id="root"></div>
       </div>
     </div>
 
   <script type="module" src="database.js"></script>
   <script type="module" src="dist/simulator.js"></script>
+  <script src="nav.js"></script>
   <script src="version.js"></script>
   </body>
 </html>

--- a/public/spells.html
+++ b/public/spells.html
@@ -33,25 +33,7 @@
   <body style="background-image: url('Art/Backgrounds/summer.png'); background-size: cover; background-attachment: fixed;">
     <div class="min-h-screen w-full bg-slate-950/80 text-slate-100 p-4 md:p-8">
       <div class="max-w-7xl mx-auto">
-        <nav class="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 shadow-lg mb-6">
-          <div class="flex items-center justify-between flex-wrap">
-            <div class="text-xl font-bold tracking-tight">Game Simulator</div>
-            <div class="flex flex-wrap gap-4">
-              <a href="index.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Home</a>
-              <a href="materials.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials</a>
-              <a href="simulator.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Simulator</a>
-              <a href="combat.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Combat</a>
-              <a href="movement.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Movement</a>
-              <a href="races.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Races</a>
-              <a href="ascension.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Ascension</a>
-              <a href="magic.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Magic</a>
-              <a href="spells.html" class="px-2 py-1 bg-emerald-600 text-white rounded">Spells</a>
-              <a href="crafting.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Crafting</a>
-              <a href="siege.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Siege</a>
-              <a href="materials_guide.html" class="px-2 py-1 text-slate-300 hover:text-emerald-400">Materials Guide</a>
-            </div>
-          </div>
-        </nav>
+        <div id="nav-container"></div>
         <div id="root"></div>
       </div>
     </div>
@@ -109,5 +91,7 @@
           .catch(error => console.error('Error loading spells:', error));
       });
     </script>
+    <script src="nav.js"></script>
+    <script src="version.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize site navigation into reusable `nav.html` and injection script
- load and highlight navigation across pages, supporting sticky headers where needed
- replace duplicated nav markup in public HTML pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2c9b046c833091229fb1ae18dd6f