### PR TITLE
refactor: centralize attack direction constants

### DIFF
--- a/src/components/AttackDirectionPanel.jsx
+++ b/src/components/AttackDirectionPanel.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-const DIRECTIONS = ["Left","Right","Up","Down"];
+import { DIRECTIONS } from "../constants/attack.js";
 
 export default function AttackDirectionPanel({ weapon, direction, setDirection, charge, setCharge, swing, setSwing }) {
   if (!weapon) return null;

--- a/src/constants/attack.js
+++ b/src/constants/attack.js
@@ -1,0 +1,1 @@
+export const DIRECTIONS = ["Left","Right","Up","Down"];

--- a/src/simulator.jsx
+++ b/src/simulator.jsx
@@ -36,6 +36,7 @@ import {
   firstMaterial,
   factorsFor,
 } from "./utils/materialHelpers.js";
+import { DIRECTIONS } from "./constants/attack.js";
 
 const STAT_POOL = 270;
 const SKILL_POOL = 500;
@@ -52,8 +53,6 @@ const races = [
   { id: "goliath", name: "Goliath", modifier: { STR: 8, DEX: -4, INT: -8, PSY: 0 }, magicProficiency: "Void" },
   { id: "fae",   name: "Fae",    modifier: { STR: -8, DEX: 0, INT: 8, PSY: -4 }, magicProficiency: "Radiance" },
 ];
-
-const DIRECTIONS = ["Left","Right","Up","Down"];
 
 function statCost(v){
   const clamp=(x)=> Math.max(0, Math.min(100, x));


### PR DESCRIPTION
## Summary
- add `DIRECTIONS` constant for reusable attack directions
- use shared constant in `AttackDirectionPanel` and `simulator`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3bfeee648330b61b1de16a92b17c