### PR TITLE
Validate database section retrieval

### DIFF
--- a/public/database.js
+++ b/public/database.js
@@ -37,7 +37,13 @@ export async function getDatabaseSection(key) {
                 }
             })();
         } else if (entry.source && entry.section) {
-            dbCache[key] = getDatabaseSection(entry.source).then(data => data[entry.section]);
+            dbCache[key] = getDatabaseSection(entry.source).then(data => {
+                const sectionData = data[entry.section];
+                if (sectionData === undefined) {
+                    throw new Error(`Section ${entry.section} not found in ${entry.source}`);
+                }
+                return sectionData;
+            });
         } else {
             throw new Error(`Invalid database entry for ${key}`);
         }

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('getDatabaseSection', () => {
   it('throws on failed fetch', async () => {
+    vi.resetModules();
     const responses = {
       'database.json': { ok: true, json: async () => ({ foo: 'foo.json' }) },
       'foo.json': { ok: false, status: 404, statusText: 'Not Found' },
@@ -15,6 +16,27 @@ describe('getDatabaseSection', () => {
     vi.stubGlobal('fetch', fetch);
     const { getDatabaseSection } = await import('../public/database.js');
     await expect(getDatabaseSection('foo')).rejects.toThrow('Failed to fetch foo.json');
+    vi.unstubAllGlobals();
+  });
+
+  it('throws if section missing', async () => {
+    vi.resetModules();
+    const responses = {
+      'database.json': {
+        ok: true,
+        json: async () => ({ base: 'base.json', missing: { source: 'base', section: 'nope' } }),
+      },
+      'base.json': { ok: true, json: async () => ({ yes: 1 }) },
+    };
+    const fetch = vi.fn(async (url) => {
+      const key = url instanceof URL ? url.pathname.split('/').pop() : url;
+      const res = responses[key];
+      if (!res) throw new Error('unknown url');
+      return res;
+    });
+    vi.stubGlobal('fetch', fetch);
+    const { getDatabaseSection } = await import('../public/database.js');
+    await expect(getDatabaseSection('missing')).rejects.toThrow('Section nope not found in base');
     vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Summary
- Ensure `getDatabaseSection` throws an explicit error when a referenced section is missing from its source.
- Add tests covering missing section scenarios and reset module state between tests.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3d1943d08330a1e1c622956b6411