### PR TITLE
clarify material subcategory sentinel

### DIFF
--- a/src/utils/materialHelpers.js
+++ b/src/utils/materialHelpers.js
@@ -2,11 +2,24 @@ export function getMaterialsForCategory(DB, cat) {
   return DB[cat] || {};
 }
 
+/**
+ * Sentinel key used in the materials database to indicate that a
+ * category has no subcategories. When this key is present, the
+ * category's items are stored directly under it.
+ */
+export const NO_SUBCATEGORY_KEY = 'A';
+
+/**
+ * Returns the list of subcategory keys for a category. Some categories
+ * store their items under {@link NO_SUBCATEGORY_KEY} to indicate the
+ * absence of real subcategories, in which case an empty array is returned.
+ */
 export function subcategoriesFor(DB, cat) {
   const obj = getMaterialsForCategory(DB, cat);
   if (Array.isArray(obj)) return [];
   const keys = Object.keys(obj || {}).sort();
-  return (keys.length === 1 && keys[0] === 'A') ? [] : keys;
+  // Categories using the sentinel key have no actual subcategories.
+  return (keys.length === 1 && keys[0] === NO_SUBCATEGORY_KEY) ? [] : keys;
 }
 
 export function itemsForCategory(DB, cat, subCat) {


### PR DESCRIPTION
## Summary
- add `NO_SUBCATEGORY_KEY` to describe categories without real subcategories
- document and utilize sentinel in `subcategoriesFor`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad422dfd148330a2c74ccde489ee63