### PR TITLE
feat: add deep clone utility with structuredClone fallback

### DIFF
--- a/src/materialCalculations.js
+++ b/src/materialCalculations.js
@@ -1,6 +1,8 @@
 // Utility for computing defensive ratings for materials.
 // Implements robust normalization and defense formulas with clearer naming.
 
+import { deepClone } from './utils/clone.js';
+
 // Calculate defensive ratings for a list of materials.
 // Each material object may contain the following engineering properties:
 //   name, class,
@@ -334,7 +336,7 @@ function feelTransform(r) {
 // prevents cross-category comparisons such as bone vs. steel.
 export function normalizeDamageFactorsByCategory(db) {
   // Work on a deep clone so the original database remains untouched.
-  const out = structuredClone(db);
+  const out = deepClone(db);
   const maxes = {};
 
   const gather = (node, top) => {

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,0 +1,8 @@
+export function deepClone(obj) {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(obj);
+  }
+  return JSON.parse(JSON.stringify(obj));
+}
+
+export default deepClone;

--- a/tests/clone.test.js
+++ b/tests/clone.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { deepClone } from '../src/utils/clone.js';
+
+describe('deepClone', () => {
+  it('uses native structuredClone when available', () => {
+    const original = globalThis.structuredClone;
+    if (!original) {
+      globalThis.structuredClone = function clone(obj) {
+        if (obj && typeof obj === 'object') {
+          const result = Array.isArray(obj) ? [] : {};
+          for (const [k, v] of Object.entries(obj)) {
+            result[k] = clone(v);
+          }
+          return result;
+        }
+        return obj;
+      };
+    }
+    const obj = { a: undefined, nested: { b: 1 } };
+    const cloned = deepClone(obj);
+    expect('a' in cloned).toBe(true);
+    expect(cloned.nested).not.toBe(obj.nested);
+    if (original) {
+      globalThis.structuredClone = original;
+    } else {
+      delete globalThis.structuredClone;
+    }
+  });
+
+  it('falls back to JSON cloning when structuredClone is unavailable', () => {
+    const original = globalThis.structuredClone;
+    globalThis.structuredClone = undefined;
+    const obj = { a: undefined, nested: { b: 1 } };
+    const cloned = deepClone(obj);
+    expect('a' in cloned).toBe(false);
+    expect(cloned.nested).not.toBe(obj.nested);
+    if (original) {
+      globalThis.structuredClone = original;
+    } else {
+      delete globalThis.structuredClone;
+    }
+  });
+});

--- a/tests/materialCalculations.test.js
+++ b/tests/materialCalculations.test.js
@@ -7,6 +7,7 @@ import {
   buildNormalizationBounds,
   scoreMaterialDefenses,
 } from '../src/materialCalculations.js';
+import { deepClone } from '../src/utils/clone.js';
 
 describe('calculateMaterialDefenses', () => {
   it('computes defense ratings within [0,1]', () => {
@@ -101,7 +102,7 @@ describe('calculateMaterialDefenses', () => {
         ]
       }
     };
-    const original = structuredClone(db);
+    const original = deepClone(db);
     const normalized = normalizeDamageFactorsByCategory(db);
     expect(db).toEqual(original);
     expect(normalized).not.toBe(db);


### PR DESCRIPTION
## Summary
- add `deepClone` helper using `structuredClone` with JSON fallback
- use `deepClone` in `normalizeDamageFactorsByCategory`
- test deepClone both with and without native `structuredClone`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc272220c83308ef84b51ee872229