### PR TITLE
Add root redirect for simulator page

### DIFF
--- a/simulator.html
+++ b/simulator.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=public/simulator.html" />
+  </head>
+  <body>
+    <p>If you are not redirected automatically, follow this <a href="public/simulator.html">link to the simulator</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `simulator.html` redirect at repository root so direct `/simulator.html` links resolve to the simulator page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc9f020708330b3a696725b509a3c