### PR TITLE
fix simulator paths and state init

### DIFF
--- a/public/simulator.html
+++ b/public/simulator.html
@@ -5,7 +5,7 @@
     <title>Game Simulator</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="aspect_ratio.js"></script>
+    <script src="./aspect_ratio.js"></script>
     <script>
       tailwind.config = {
         theme: {
@@ -41,9 +41,9 @@
       </div>
     </div>
 
-  <script type="module" src="database.js"></script>
-  <script type="module" src="dist/simulator.js"></script>
-  <script src="nav.js"></script>
-  <script src="version.js"></script>
+  <script type="module" src="./database.js"></script>
+  <script type="module" src="./dist/simulator.js"></script>
+  <script src="./nav.js"></script>
+  <script src="./version.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load simulator scripts via explicit relative paths
- initialize armor state before race-based adjustments
- ensure health and stamina state logic runs after stamina/mana calculations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adcf1f24348330a7966c671d6840a2