### PR TITLE
Guard simulator page against missing Tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <title>Redirecting...</title>
-    <meta http-equiv="refresh" content="0; url=public/index.html" />
+    <script>
+      const base = window.location.pathname.replace(/[^/]*$/, '');
+      const target = `${base}public/index.html`;
+      window.location.replace(target);
+    </script>
   </head>
   <body>
-    <p>If you are not redirected automatically, follow this <a href="public/index.html">link to the simulator</a>.</p>
+    <p>If you are not redirected automatically, follow this <a id="redirect-link" href="#">link to the site</a>.</p>
+    <script>
+      const base = window.location.pathname.replace(/[^/]*$/, '');
+      const target = `${base}public/index.html`;
+      document.getElementById('redirect-link').href = target;
+    </script>
   </body>
 </html>

--- a/public/simulator.html
+++ b/public/simulator.html
@@ -7,17 +7,19 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="./aspect_ratio.js"></script>
     <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            screens: {
-              "aspect-ultrawide": { "raw": "[data-aspect-ratio='ultrawide']" },
-              "aspect-widescreen": { "raw": "[data-aspect-ratio='widescreen']" },
-              "aspect-mobile": { "raw": "[data-aspect-ratio='mobile']" },
+      if (window.tailwind) {
+        tailwind.config = {
+          theme: {
+            extend: {
+              screens: {
+                "aspect-ultrawide": { "raw": "[data-aspect-ratio='ultrawide']" },
+                "aspect-widescreen": { "raw": "[data-aspect-ratio='widescreen']" },
+                "aspect-mobile": { "raw": "[data-aspect-ratio='mobile']" },
+              },
             },
           },
-        },
-      };
+        };
+      }
       document.documentElement.classList.add("dark");
     </script>
     <style>

--- a/simulator.html
+++ b/simulator.html
@@ -3,9 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <title>Redirecting...</title>
-    <meta http-equiv="refresh" content="0; url=public/simulator.html" />
+    <script>
+      const base = window.location.pathname.replace(/[^/]*$/, '');
+      const target = `${base}public/simulator.html`;
+      window.location.replace(target);
+    </script>
   </head>
   <body>
-    <p>If you are not redirected automatically, follow this <a href="public/simulator.html">link to the simulator</a>.</p>
+    <p>If you are not redirected automatically, follow this <a id="redirect-link" href="#">link to the simulator</a>.</p>
+    <script>
+      const base = window.location.pathname.replace(/[^/]*$/, '');
+      const target = `${base}public/simulator.html`;
+      document.getElementById('redirect-link').href = target;
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid crashing when Tailwind CDN fails by guarding configuration on simulator page
- ensure GitHub Pages and local hosting serve the same content by redirecting root pages to `public`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add570f92883308f843c4a8827424c