### PR TITLE
Fix wood item tooltip in materials database

### DIFF
--- a/public/materials.html
+++ b/public/materials.html
@@ -90,7 +90,14 @@
             db['Wood'] = Object.fromEntries(
               Object.entries(woods).map(([type, list]) => [
                 toTitleCase(type),
-                list.map(name => ({ id: slug(name), name: toTitleCase(name), ...(woodProps[name] || {}) }))
+                list.map(name => {
+                  const factors = woodProps[name];
+                  return {
+                    id: slug(name),
+                    name: toTitleCase(name),
+                    ...(factors ? { factors } : {})
+                  };
+                })
               ])
             );
 


### PR DESCRIPTION
## Summary
- Wrap wood properties in a `factors` object so wood entries show their details on click in the materials database

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adfc7fe4cc8330a57a070dc3f0088e